### PR TITLE
Fix incorrect handling of missing fields by morpc.frictionless.cast_field_types

### DIFF
--- a/morpc/census/geos.py
+++ b/morpc/census/geos.py
@@ -69,9 +69,9 @@ MORPC_REGION_SCOPES = [
         "for": f"county:{','.join([morpc.CONST_COUNTY_NAME_TO_ID[x][2:6] for x in morpc.CONST_REGIONS['Mobility Region']])}"
         }
         },
-    {"regionmpo":{
+    {"regionfradel":{
         "in": "state:39",
-        "for": f"county:{','.join([morpc.CONST_COUNTY_NAME_TO_ID[x][2:6] for x in morpc.CONST_REGIONS['MPO Region']])}"
+        "for": f"county:{','.join([morpc.CONST_COUNTY_NAME_TO_ID[x][2:6] for x in morpc.CONST_REGIONS['FRADEL']])}"
     }}
 ]
 

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -172,18 +172,21 @@ def cast_field_types(df, schema, forceInteger:bool=False, forceInt64:bool=False,
         for nullValue in schema.missing_values:
             outDF = outDF.replace(nullValue, None)
 
-        if(handleMissingFields == "ignore"):
-            logger.info(f"Ignoring missing fields")
-        elif(handleMissingFields == "add"):
-            logger.info("Adding missing fields which is not present in dataframe")
-            outDF = add_missing_fields(df, schema)
-        else:
-            logger.error("Fields in schema is not present in dataframe. To handle missing fields, see argument handleMissingFields.")
-            raise RuntimeError
-    
     for field in schema.fields:
         fieldName = field.name
-        fieldType = field.type
+        fieldType = field.type 
+        if(not fieldName in df.columns):
+            if(handleMissingFields == "ignore"):
+                logger.info("Skipping field {} which is not present in dataframe".format(fieldName))
+                continue
+            elif(handleMissingFields == "add"):
+                logger.info("Adding field {} which is not present in dataframe".format(fieldName))
+                add_missing_fields(df, schema, fieldNames=fieldName, verbose=False)
+                continue
+            else:
+                logger.error("Field {} is not present in dataframe. To handle missing fields, see argument handleMissingFields.".format(fieldName))
+                raise RuntimeError
+   
         logger.debug("Casting field {} as type {}.".format(fieldName, fieldType))
         # The following section is necessary because the pandas "int" type does not support null values.  If null values are present,
         # the field must be cast as "Int64" instead.

--- a/morpc/morpc.py
+++ b/morpc/morpc.py
@@ -178,7 +178,7 @@ CONST_REGIONS["REGIONCEDS"] = CONST_REGIONS["REGION10"] + ["Logan"]
 CONST_REGIONS["CEDS Region"] = CONST_REGIONS["REGIONCEDS"]
 CONST_REGIONS["CBSA"] = CONST_REGIONS["REGION7"] + ["Hocking","Morrow","Perry"]
 CONST_REGIONS['Mobility Region'] = CONST_REGIONS['REGION7'] + ['Logan', 'Fayette']
-CONST_REGIONS['MPO Region'] = ['Delaware', 'Franklin']
+CONST_REGIONS['FRADEL'] = ['Delaware', 'Franklin']
 
 # Region identifiers
 # Note that the Columbus MSA already has a GEOID that is defined by the Census Bureau.  See CONST_COLUMBUS_MSA_ID above.
@@ -196,7 +196,7 @@ CONST_REGIONS_GEOID["CBSA"] = CONST_COLUMBUS_CBSA_ID
 
 # The following regions are comprised of collections of whole counties. Not all region definitions are county-based,
 # for example the MPO region.
-CONST_REGIONS_COUNTYBASED = ["REGION15","REGION10","REGION7","REGIONCEDS","REGIONCORPO","REGIONONECBUS","CBSA"]
+CONST_REGIONS_COUNTYBASED = ["REGION15","REGION10","REGION7","REGIONCEDS","REGIONCORPO","REGIONONECBUS","CBSA","FRADEL"]
 
 # County name abbreviations
 ## CONST_COUNTY_ABBREV maps the full county name to its three-letter abbreviation


### PR DESCRIPTION
Not sure if the reverted change was intentional or not but it was incorrectly raising an exception for me when the columns in my dataframe matched the columns in the schema.

Resolves #139 

Also included another change that I failed to merge previously to refer to Franklin + Delaware counties as FRADEL rather than "MPO region"