### PR TITLE
Fix unused numpy.NaN import incompatible with NumPy 2.0

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -10,7 +10,6 @@ from typing import Literal, List
 import datetime
 from frictionless import Resource, Schema
 import frictionless
-from numpy import NaN
 from pandas import NaT
 import pandas
 from semantic_version import Version


### PR DESCRIPTION
## Summary

- Removes `from numpy import NaN` from `morpc/frictionless/frictionless.py` — `NaN` was never used in the file and `numpy.NaN` was removed in NumPy 2.0
- Bumps version to `0.5.1`

## Test plan

- [ ] Build check passes
- [ ] `import morpc` works cleanly with NumPy 2.x installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)