### PR TITLE
Declare semantic-version as explicit dependency, bump to 0.5.2

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pandas",
     "geopandas",
     "frictionless",
+    "semantic-version>=2.10",
     "shapely",
     "IPython",
     "xlsxwriter",


### PR DESCRIPTION
## Summary

- Adds `semantic-version>=2.10` to `pyproject.toml` — `morpc/frictionless/frictionless.py` imports it directly but it was never declared as a dependency
- It was previously installed transitively via `frictionless`, but newer versions of `frictionless` dropped it, causing `ModuleNotFoundError` on clean installs
- Bumps version to `0.5.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)