### PR TITLE
Fix Python 3.10 f-string syntax errors, bump to 0.5.4

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/rest_api/rest_api.py
+++ b/morpc/rest_api/rest_api.py
@@ -65,7 +65,7 @@ def resource(name, url, where='1=1', outfields='*', max_record_count=None, **kwa
         for k, v in kwargs.items():
             query.update({k: v})
 
-    logger.info(f"Query Params: {[f"{k}={v}" for k,v in query.items()]}")
+    logger.info(f"Query Params: {[f'{k}={v}' for k,v in query.items()]}")
 
     # Get the total record count
     try:

--- a/morpc/utils.py
+++ b/morpc/utils.py
@@ -163,7 +163,7 @@ class DataFrameSummary:
                     data_summary += f"{df[column].describe().to_markdown()}\n"
                     data_summary += f"**Missing**:     {(sum(df[column].isna())/len(df[column]))*100:.2f}%  \n"
                     data_summary += f"**Unique**:      {(len([x for x in df[column].unique()])/len(df[column]))*100:.2f}%  \n"
-                    data_summary += f"**Sample**:      {", ".join(df[column].sample(10, ).fillna('<NA>').to_list())}  \n"
+                    data_summary += f"**Sample**:      {', '.join(df[column].sample(10, ).fillna('<NA>').to_list())}  \n"
 
                 if type in ['Int64', 'int', 'float64', 'datetime64[ns]']:
                     data_summary += f"{df[column].describe().to_markdown()}\n"


### PR DESCRIPTION
## Summary

Python 3.10 does not allow same-quote-type strings inside f-string expressions. Two files had this issue:

- `morpc/rest_api/rest_api.py:68` — nested `f"{k}={v}"` inside `f"...{[...]}..."` (inner changed to single quotes)
- `morpc/utils.py:166` — `", ".join(...)` inside `f"..."` (separator changed to single quotes)

Bumps version to `0.5.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)