### PR TITLE
Add show_progress parameter to ArcGISResource.to_geodataframe()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`morpc` is a Python library (published to PyPI) providing constants, mappings, and shared functions for MORPC data workflows. Python >=3.10 is required.
+
+## Models & Agents
+
+- Default to **Sonnet** for all code work.
+- Use **Opus** for coordination, architecture, high-level design, and conceptual planning.
+- Use **Haiku** for simple lookups, reading files, and lightweight tasks.
+- Use subagents for all non-trivial code work. Spawn agents with the appropriate model for the task.
+
+## Git Workflow
+
+### Before starting any work
+1. Check the current branch. **Never make code changes directly on `main`.**
+2. Ask the user which branch to work on, or propose a branch name and ask for confirmation before creating it.
+3. Create the branch and switch to it before making any changes.
+
+### While working
+- Commit in logical units with clear, descriptive commit messages.
+- Write tests for new functionality.
+- Update documentation when behavior changes.
+
+### When work is complete
+1. Ask the user if they want to open a pull request.
+2. If yes, push the branch and create a PR with a summary of what changed and why.
+
+### Rules
+- Never commit directly to `main` or `master`.
+- Never force-push without explicit user confirmation.
+- Always confirm before destructive git operations (reset --hard, branch deletion, etc.).
+
+## Commands
+
+### Development Setup
+```bash
+pip install -e ".[dev]"
+```
+
+### Running Tests
+```bash
+pytest
+# Run a single test:
+pytest tests/test_utils.py::test_function_name
+```
+
+### Building for Release
+```bash
+python3 -m pip install build
+python3 -m build
+```
+
+### Release Process
+Bump `__version__` in `morpc/__init__.py`, commit and push, then create a GitHub Release with a matching tag (e.g. `v0.5.5`). CI handles PyPI publish and docs deploy automatically.
+
+## Architecture
+
+### Package Structure
+
+The public API is assembled in `morpc/__init__.py`, which re-exports everything from all submodules. Most constants and functions live in the monolithic `morpc/morpc.py` (~3700 lines); subpackages (`frictionless/`, `color/`, `plot/`, `rest_api/`) each have a thin `__init__.py` that re-exports from their implementation module.
+
+### Core Module (`morpc/morpc.py`)
+
+The central file. Contains:
+
+- **Geographic constants**: `CONST_REGIONS` (region name → county list for REGION7, REGION10, REGION15, CBSA, etc.), `CONST_COUNTY_NAME_TO_ID`, state name/abbr/ID lookup dicts
+- **Census summary levels**: `SUMLEVEL_DESCRIPTIONS` (codes `'010'`–`'M30'`), `SUMLEVEL_LOOKUP`, `HIERARCHY_STRING_LOOKUP` — detailed census and MORPC geography hierarchy metadata
+- **Data I/O**: `load_spatial_data()`, `load_tabular_data()`, `write_table()` (enforces `\r\n` CSV endings), `wget()`
+- **DataFrame utilities**: `round_preserve_sum()`, `compute_group_sum()`, `compute_group_share()`, `compute_controlled_values()`, `control_variable_to_group()`, `update_existing_table()`
+- **Lookup classes**: `countyLookup(scope)` (county GEOID/name resolution), `varLookup(...)` (variable dictionary — depends on external `../morpc-lookup/` repo), `generations()` (birth-year → generation), `bls()` (QCEW aggregation codes)
+- **Spatial**: `assign_geo_identifiers()` (point-in-polygon using TIGER layers), `reapportion_by_area()` (areal interpolation)
+- **Avro/legacy**: `cast_field_types(df, schema)` using Avro schema — superseded by the frictionless workflow
+
+### Frictionless Workflow (`morpc/frictionless/`)
+
+The preferred pattern for data loading and saving in MORPC pipelines:
+- Data files are paired with `.resource.yaml` and `.schema.yaml` sidecars
+- `load_data(resourcePath)` — primary entry point; loads data + applies schema type casting
+- `create_resource(dataPath, ...)` — build a frictionless Resource descriptor
+- `create_package(dir, resources, ...)` — bundle resources into a data package
+- `cast_field_types(df, schema)` — type-cast a DataFrame per frictionless schema fields
+- `schema_from_avro(path)` — migrate legacy Avro schemas to frictionless format
+
+### REST API (`morpc/rest_api/`)
+
+ArcGIS Online REST API tools:
+- `gdf_from_resource(resource)` — fetch all features from an ArcGIS REST service as a GeoDataFrame, handling pagination automatically
+- `resource(name, url, ...)` — build a frictionless Resource from a REST service URL
+- `schema(url, outfields)` — fetch ArcGIS field definitions as a frictionless Schema
+
+### Plot (`morpc/plot/`)
+
+- `morpc_theme` (`plot.py`) — plotnine theme subclassing `theme_classic` with MORPC branding
+- `MAP` (`map.py`) — folium-based interactive choropleth for GeoDataFrames; `BindColormap` for legend binding
+- `ExcelChart` / `data_chart_to_excel()` (`excel.py`) — build Excel charts via xlsxwriter
+
+### Color (`morpc/color/`)
+
+- `GetColors` (`colors.py`) — loads `morpc_colors_2026.yaml` via `importlib.resources`; provides `.KEYS()`, `.SEQ()` (sequential palettes), and other palette accessors
+- `CONST_MORPC_COLORS` and `CONST_COLOR_CYCLES` in `morpc.py` are the older dict-based color API
+
+### Utilities (`morpc/utils.py`, `morpc/logs.py`, `morpc/req.py`, `morpc/geocode.py`)
+
+- `datetime_from_string(date, errors)` — flexible datetime parser; handles NaT, datetime objects, integer epochs (ns/ms/s), ISO 8601, YYYYMMDD, YYYYMM, natural language
+- `DataFrameSummary(df, ...)` — markdown descriptive stats summary
+- `config_logs(filename, level, mode)` — logging to file + stdout for notebook workflows
+- `get_json_safely()`, `get_text_safely()`, `get_file()` — HTTP helpers with retry logic
+- `geocode(addresses, endpoint)` — Nominatim geocoding (public or local Docker)
+
+## Key Conventions
+
+- **CSV line endings**: Always `\r\n` (Windows). `write_table()` enforces this via `PANDAS_EXPORT_ARGS_OVERRIDE`. This ensures consistent MD5 checksums cross-platform.
+- **Logging**: All modules use `logging.getLogger(__name__)`. Older code in `morpc.py` uses `print()` with `morpc.function | LEVEL |` prefix — this is legacy and should not be extended.
+- **TODO automation**: `# TODO:` comments are automatically converted to GitHub Issues on push via `.github/workflows/todo_to_issue.yml`.
+- **External dependency**: `varLookup` expects `../morpc-lookup/variable_dictionary.xlsx` — a separate repo not bundled here.
+- **Missing declared deps**: `geopy`, `tqdm`, and `folium` are used in source but not listed in `pyproject.toml`. Add them when touching those modules.
+
+## CI/CD
+
+- **PyPI publish**: triggered by creating a GitHub Release (`.github/workflows/python-publish.yml`); builds on `windows-latest`, uses OIDC trusted publishing
+- **Docs**: MyST Markdown + Jupyter notebooks in `doc/`; deployed to GitHub Pages on push to `main` via `myst build --html`

--- a/morpc/rest_api/__init__.py
+++ b/morpc/rest_api/__init__.py
@@ -1,1 +1,1 @@
-from .rest_api import *
+from .rest_api import ArcGISResource, ArcGISSchema, ESRI_TYPE_MAP, gdf_from_resource, maxRecordCount, resource, schema, totalRecordCount

--- a/morpc/rest_api/__init__.py
+++ b/morpc/rest_api/__init__.py
@@ -1,1 +1,1 @@
-from .rest_api import ArcGISPlugin, ArcGISResource, ArcGISSchema, ESRI_TYPE_MAP, gdf_from_resource, maxRecordCount, resource, schema, totalRecordCount
+from .rest_api import ArcGISControl, ArcGISPlugin, ArcGISResource, ArcGISSchema, ESRI_TYPE_MAP, gdf_from_resource, maxRecordCount, resource, schema, totalRecordCount

--- a/morpc/rest_api/__init__.py
+++ b/morpc/rest_api/__init__.py
@@ -1,1 +1,1 @@
-from .rest_api import ArcGISResource, ArcGISSchema, ESRI_TYPE_MAP, gdf_from_resource, maxRecordCount, resource, schema, totalRecordCount
+from .rest_api import ArcGISPlugin, ArcGISResource, ArcGISSchema, ESRI_TYPE_MAP, gdf_from_resource, maxRecordCount, resource, schema, totalRecordCount

--- a/morpc/rest_api/rest_api.py
+++ b/morpc/rest_api/rest_api.py
@@ -183,7 +183,7 @@ class ArcGISResource(frictionless.Resource):
 
         return cls(descriptor)
 
-    def to_geodataframe(self, out_fields: list[str] | None = None, CRS='epsg:4326'):
+    def to_geodataframe(self, out_fields: list[str] | None = None, CRS='epsg:4326', show_progress: bool = True):
         """Fetch all features from the ArcGIS service as a GeoDataFrame.
 
         Parameters
@@ -225,33 +225,34 @@ class ArcGISResource(frictionless.Resource):
         gdfs = []
         with Session() as session:
             with enlighten.Manager() as manager:
-                with manager.counter(total=len(urls), desc='Downloading:', unit='requests') as pb:
-                    for url in urls:
-                        logger.debug(f"Fetching {url}")
-                        r = session.get(url)
-                        while r.status_code != 200:
-                            logger.warning(f"Status Code {r.status_code}, trying again. URL: {r.url}")
-                            if r.status_code == 400 and "Output format not supported" in r.text:
-                                url = url.replace('geojson', 'json').replace('&returnGeometry=true', '')
-                                logger.warning(f"Output format not supported, trying json. {url}")
-                            sleep(1)
-                            r = session.get(url, headers=headers)
+                pb = manager.counter(total=len(urls), desc='Downloading:', unit='requests') if show_progress else None
+                for url in urls:
+                    logger.debug(f"Fetching {url}")
+                    r = session.get(url)
+                    while r.status_code != 200:
+                        logger.warning(f"Status Code {r.status_code}, trying again. URL: {r.url}")
+                        if r.status_code == 400 and "Output format not supported" in r.text:
+                            url = url.replace('geojson', 'json').replace('&returnGeometry=true', '')
+                            logger.warning(f"Output format not supported, trying json. {url}")
+                        sleep(1)
+                        r = session.get(url, headers=headers)
 
-                        try:
-                            json_data = r.json()
-                        except JSONDecodeError:
-                            logger.error(f"Failed to decode json. {r.content}")
-                            raise
+                    try:
+                        json_data = r.json()
+                    except JSONDecodeError:
+                        logger.error(f"Failed to decode json. {r.content}")
+                        raise
 
-                        try:
-                            gdf = gpd.GeoDataFrame.from_features(json_data)
-                        except Exception as e:
-                            logger.error(f"Failed to create GeoDataFrame. {e}")
-                            logger.error(f"{r.url}")
-                            logger.error(f"{json_data}")
-                            raise RuntimeError(f"Failed to create GeoDataFrame: {e}")
+                    try:
+                        gdf = gpd.GeoDataFrame.from_features(json_data)
+                    except Exception as e:
+                        logger.error(f"Failed to create GeoDataFrame. {e}")
+                        logger.error(f"{r.url}")
+                        logger.error(f"{json_data}")
+                        raise RuntimeError(f"Failed to create GeoDataFrame: {e}")
 
-                        gdfs.append(gdf)
+                    gdfs.append(gdf)
+                    if pb is not None:
                         pb.update()
 
         gdf = pd.concat(gdfs)

--- a/morpc/rest_api/rest_api.py
+++ b/morpc/rest_api/rest_api.py
@@ -10,7 +10,9 @@ import re
 import urllib.parse
 from json import JSONDecodeError
 
+import attrs
 import frictionless
+from frictionless.dialect import Control
 from requests import HTTPError
 
 from morpc.req import get_json_safely
@@ -68,12 +70,35 @@ class ArcGISSchema(frictionless.Schema):
         return cls({'fields': fields})
 
 
+@attrs.define(kw_only=True, repr=False)
+class ArcGISControl(Control):
+    """Control for ArcGIS REST API query parameters and service pagination metadata."""
+
+    type = "arcgis"
+
+    total_records: int = 0
+    max_record_count: int = 500
+    query: dict = attrs.Factory(dict)
+
+    metadata_profile_patch = {
+        "properties": {
+            "totalRecords": {"type": "integer"},
+            "maxRecordCount": {"type": "integer"},
+            "query": {"type": "object"},
+        }
+    }
+
+
 class ArcGISPlugin(frictionless.Plugin):
-    """Frictionless plugin that registers ArcGISResource as the handler for type='arcgis'."""
+    """Frictionless plugin that registers ArcGIS classes for type='arcgis'."""
 
     def select_resource_class(self, type=None, *, datatype=None):
         if type == "arcgis":
             return ArcGISResource
+
+    def select_control_class(self, type=None):
+        if type == "arcgis":
+            return ArcGISControl
 
 
 frictionless.system.register("arcgis", ArcGISPlugin())
@@ -135,6 +160,17 @@ class ArcGISResource(frictionless.Resource):
                 max_record_count = min(total_record_count, 500)
             logger.info(f"Fetching {max_record_count} at a time.")
 
+        control = ArcGISControl(
+            total_records=total_record_count,
+            max_record_count=max_record_count,
+            query={
+                'where': where,
+                'outFields': outfields,
+                **kwargs,
+            },
+        )
+        dialect = frictionless.Dialect(controls=[control])
+
         descriptor = {
             "name": re.sub(r'[:/_ ]', '-', name).lower(),
             "type": "arcgis",
@@ -142,12 +178,7 @@ class ArcGISResource(frictionless.Resource):
             "path": url,
             "schema": ArcGISSchema.from_url(url, outfields=outfields).to_descriptor(),
             "mediatype": "application/geo+json",
-            "_metadata": {
-                "type": "arcgis_service",
-                "params": query,
-                "total_records": total_record_count,
-                "max_record_count": max_record_count,
-            },
+            "dialect": dialect.to_descriptor(),
         }
 
         return cls(descriptor)
@@ -176,15 +207,19 @@ class ArcGISResource(frictionless.Resource):
                     logger.error(f"field {field} not in resource fields: {self.schema.field_names}")
                     raise ValueError(f"field {field} not in resource fields")
 
-        metadata = self.to_dict()['_metadata']
+        control = ArcGISControl.from_dialect(self.dialect)
 
         urls = []
-        for offset in range(0, metadata['total_records'], metadata['max_record_count']):
-            params = dict(metadata['params'])
+        for offset in range(0, control.total_records, control.max_record_count):
+            params = {
+                **control.query,
+                'returnGeometry': 'true',
+                'f': 'geojson',
+                'resultRecordCount': control.max_record_count,
+                'resultOffset': offset,
+            }
             if out_fields is not None:
                 params['outFields'] = ",".join(out_fields)
-            params['resultRecordCount'] = metadata['max_record_count']
-            params['resultOffset'] = offset
             urls.append(f"{self.path}/query?" + urllib.parse.urlencode(params, safe="=(),"))
 
         gdfs = []
@@ -220,8 +255,8 @@ class ArcGISResource(frictionless.Resource):
                         pb.update()
 
         gdf = pd.concat(gdfs)
-        if len(gdf) != metadata['total_records']:
-            logger.error(f"Record count mismatch. Expected {metadata['total_records']}, got {len(gdf)}")
+        if len(gdf) != control.total_records:
+            logger.error(f"Record count mismatch. Expected {control.total_records}, got {len(gdf)}")
 
         return gdf.set_crs(CRS)
 

--- a/morpc/rest_api/rest_api.py
+++ b/morpc/rest_api/rest_api.py
@@ -68,6 +68,17 @@ class ArcGISSchema(frictionless.Schema):
         return cls({'fields': fields})
 
 
+class ArcGISPlugin(frictionless.Plugin):
+    """Frictionless plugin that registers ArcGISResource as the handler for type='arcgis'."""
+
+    def select_resource_class(self, type=None, *, datatype=None):
+        if type == "arcgis":
+            return ArcGISResource
+
+
+frictionless.system.register("arcgis", ArcGISPlugin())
+
+
 class ArcGISResource(frictionless.Resource):
     """A frictionless Resource representing an ArcGIS REST API service.
 
@@ -75,6 +86,8 @@ class ArcGISResource(frictionless.Resource):
     frictionless.Resource interface, or use from_url() to fetch metadata from
     a live ArcGIS REST service.
     """
+
+    type = "arcgis"
 
     @classmethod
     def from_url(cls, name, url, where='1=1', outfields='*', max_record_count=None, **kwargs):
@@ -124,6 +137,7 @@ class ArcGISResource(frictionless.Resource):
 
         descriptor = {
             "name": re.sub(r'[:/_ ]', '-', name).lower(),
+            "type": "arcgis",
             "format": "json",
             "path": url,
             "schema": ArcGISSchema.from_url(url, outfields=outfields).to_descriptor(),

--- a/morpc/rest_api/rest_api.py
+++ b/morpc/rest_api/rest_api.py
@@ -1,354 +1,283 @@
 # morpc-py/morpc/rest_api/rest_api.py
 
 """REST API module for MORPC.
-This module provides functions to interact with ArcGIS REST API services,
-including fetching data, converting ESRI WKID to WKT2, and creating frictionless resources
-from ArcGIS services.
+This module provides tools to interact with ArcGIS REST API services,
+including fetching data, schema introspection, and creating frictionless resources.
 """
 
-import itertools
-from json import JSONDecodeError
 import logging
-from types import NoneType
-from typing import List
+import re
 import urllib.parse
+from json import JSONDecodeError
 
-from pandas import concat
+import frictionless
 from requests import HTTPError
-import urllib
+
 from morpc.req import get_json_safely
 
 logger = logging.getLogger(__name__)
 
-def resource(name, url, where='1=1', outfields='*', max_record_count=None, **kwargs):
-    """Creates a frictionless Resource object from an ArcGIS REST API service URL.
+ESRI_TYPE_MAP = {
+    'oid':          'string',
+    'globalid':     'string',
+    'guid':         'string',
+    'string':       'string',
+    'xml':          'string',
+    'blob':         'string',
+    'raster':       'string',
+    'integer':      'integer',
+    'smallinteger': 'integer',
+    'double':       'number',
+    'single':       'number',
+    'date':         'datetime',
+}
 
-    Parameters:
-    ----------- 
-    name : str
-        The name of the resource, which will be used to create a valid resource name.
-    
-    url : str
-        The URL of the ArcGIS REST API service. 
 
-    where : str, optional
-        A SQL-like query string to filter the results. Default is '1=1', which returns all records. 
-    
-    outfields : str, optional
-        A comma-separated list of field names to include in the results. Default is '*', which
-        includes all fields.
-    
-    max_record_count : int, optional
-        The maximum number of records to fetch in a single request. If not provided, it defaults
-        to 500 if the total record count exceeds 500, otherwise it uses the total record count.
+class ArcGISSchema(frictionless.Schema):
+    """A frictionless Schema built from an ArcGIS REST service field list."""
 
-    Returns:
-    --------    
-    resource : frictionless.Resource
-        A frictionless Resource object containing the schema and metadata of the service.
+    @classmethod
+    def from_url(cls, url, outfields=None):
+        """Fetch field definitions from an ArcGIS REST service and return an ArcGISSchema.
 
+        Parameters
+        ----------
+        url : str
+            Base URL of the ArcGIS REST service.
+        outfields : str, optional
+            Comma-separated field names to include, or '*' / None for all fields.
+        """
+        logger.info(f"Fetching schema metadata from {url}?f=pjson")
+        pjson = get_json_safely(f"{url}?f=pjson")
+
+        requested = None if outfields in (None, '*') else set(outfields.split(','))
+
+        fields = []
+        for field in pjson['fields']:
+            if requested is not None and field['name'] not in requested:
+                continue
+            esri_type = field['type'].replace('esriFieldType', '').lower()
+            if esri_type == 'geometry':
+                continue
+            frictionless_type = ESRI_TYPE_MAP.get(esri_type)
+            if frictionless_type is None:
+                logger.warning(f"Unknown ESRI type '{esri_type}' for field '{field['name']}', defaulting to 'string'")
+                frictionless_type = 'string'
+            fields.append({'name': field['name'], 'title': field['alias'], 'type': frictionless_type})
+
+        return cls({'fields': fields})
+
+
+class ArcGISResource(frictionless.Resource):
+    """A frictionless Resource representing an ArcGIS REST API service.
+
+    Construct from an existing descriptor or resource file using the inherited
+    frictionless.Resource interface, or use from_url() to fetch metadata from
+    a live ArcGIS REST service.
     """
-    import frictionless
-    import re
-    from morpc.rest_api import totalRecordCount, schema
-    import urllib.parse
-            
-    # Construct the query parameters
-    query = {
-        'where': where, 
-        'outFields': outfields, 
-        'returnGeometry': 'true', 
-        'f': 'geojson'
-    }
 
-    if len(kwargs):
-        for k, v in kwargs.items():
-            query.update({k: v})
+    @classmethod
+    def from_url(cls, name, url, where='1=1', outfields='*', max_record_count=None, **kwargs):
+        """Create an ArcGISResource by fetching metadata from an ArcGIS REST service URL.
 
-    logger.info(f"Query Params: {[f'{k}={v}' for k,v in query.items()]}")
-
-    # Get the total record count
-    try:
-        total_record_count = totalRecordCount(url, **query)
-    except HTTPError as e:
-        logger.error(f"Failed to get total record count, HTTPError: {e}")
-
-    logger.info(f"Total number of geographies: {total_record_count}")
-    
-    # Determine the max record count
-    if max_record_count is None:
-        try:
-            max_record_count = maxRecordCount(url)
-        except ValueError as e:
-            logger.warning(f"Unable to find maxRecordCount. Using default.")
-            if total_record_count > 500:
-                max_record_count = 500
-            else:
-                max_record_count = total_record_count
-        logger.info(f"Fetching {max_record_count} at a time.")
-
-    # Construct the frictionless Resource object
-    resource = {
-        "name": re.sub('[:/_ ]', '-', name).lower(),
-        "format": "json",
-        "path": url,
-        "schema": schema(url, outfields=outfields),
-        "mediatype": "application/geo+json",
-        "_metadata": {
-            "type": "arcgis_service",
-            "params": query,
-            "total_records": total_record_count,
-            "max_record_count": max_record_count
+        Parameters
+        ----------
+        name : str
+            Human-readable name; converted to a valid resource slug.
+        url : str
+            Base URL of the ArcGIS REST service (without /query).
+        where : str, optional
+            SQL WHERE clause to filter records. Default '1=1' returns all.
+        outfields : str, optional
+            Comma-separated field names, or '*' for all fields.
+        max_record_count : int, optional
+            Records per paginated request. Fetched from the service if omitted;
+            falls back to 500 if the service does not advertise a limit.
+        **kwargs
+            Additional ArcGIS query parameters (e.g. orderByFields).
+        """
+        query = {
+            'where': where,
+            'outFields': outfields,
+            'returnGeometry': 'true',
+            'f': 'geojson',
+            **kwargs,
         }
-    }
 
-    return frictionless.Resource(resource)
+        logger.info(f"Query Params: {[f'{k}={v}' for k, v in query.items()]}")
 
-def gdf_from_resource(resource, out_fields: List[str] | None = None, CRS = 'epsg:4326'):
-    """Creates a GeoDataFrame from resource file for an ArcGIS Services. Automatically queries for maxRecordCount and
-    iterates over the whole feature layer to return all features. Optional: Filter the results by including a list of field
-    IDs.
-
-    Example Usage:
-
-    Parameters:
-    ------------
-    resource : str
-        A frictionless.Resource or path to the resource file, which can be a local file or a URL to an ArcGIS REST API service.
-
-    out_fields : list[str]
-        A list of strings representing the fields to include in the query.
-    Returns:
-    ----------
-    gdf : pandas.core.frame.DataFrame
-        A GeoPandas GeoDataframe constructed from the GeoJSON requested from the url.
-
-    """
-
-    from requests import Session
-    import frictionless
-    import enlighten
-    import geopandas as gpd
-    import pandas as pd
-    from time import sleep
-
-
-    headers = {"User-Agent": "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"}
-    # Check if the resource is a string or a frictionless Resource object
-    if isinstance(resource, str):
-        # If it's a string, create a frictionless Resource object from the URL or file path
-        resource = frictionless.Resource(path=resource)
-    elif isinstance(resource, frictionless.Resource):
-        # If it's already a Resource object, use it directly
-        pass
-
-    if not isinstance(out_fields, NoneType):
-        for field in out_fields:
-            if field not in resource.schema.field_names:
-                logger.error(f"field {field} not in resource fields: {resource.schema.field_names}")
-                raise ValueError
-
-    metadata = resource.to_dict()['_metadata']
-
-    offsets = [x for x in range(0, metadata['total_records'], metadata['max_record_count'])]
-
-    # Construct URLS for each request based on offsets
-    urls = []
-    if len(offsets) > 1:
-        for offset in offsets:
-            url = resource.path
-            params = metadata['params']
-            if not isinstance(out_fields, NoneType):
-                params.update({'outFields': ",".join(out_fields)})
-            params.update({'resultRecordCount': metadata['max_record_count']})
-            params.update({'resultOffset': offset})
-            url = f"{resource.path}/query?" + urllib.parse.urlencode(params, safe=",()")
-            urls.append(url)
-    else:
-        url = resource.path
-        params = metadata['params']
-        if not isinstance(out_fields, NoneType):
-            params.update({'outFields': ",".join(out_fields)})
-        url = f"{resource.path}/query?" + urllib.parse.urlencode(params, safe=",()")
-        urls.append(url)
-
-    # Fetch the GeoJSON data in chunks via source urls constructed above
-    gdfs = []
-    with Session() as session:
-        with enlighten.Manager() as manager: # Load progress bar
-            with manager.counter(total=len(urls), desc='Downloading:', unit='requests') as pb:
-                for url in urls:
-                    logger.debug(f"Fetching {url}")
-                    r = session.get(url)
-                    while r.status_code != 200:
-                        logger.warning(f"Status Code {r.status_code}, trying again. URL: {r.url}")
-                        if r.status_code == 400:
-                            if "Output format not supported" in r.text:
-                                url = url.replace('geojson', 'json').replace('&returnGeometry=true','')
-                                logger.warning(f"Output format not supported, trying json. {url}")
-                        sleep(1)
-                        r = session.get(url, headers=headers)
-
-                    try:
-                        json = r.json()
-                    except JSONDecodeError as e:
-                        logger.error(f"Failed to decode json. {r.content}")
-                        raise JSONDecodeError(e)
-
-                    try:
-                        gdf = gpd.GeoDataFrame.from_features(json)
-                    except Exception as e:
-                        logger.error(f"Failed to create gdf. {e}")
-                        logger.error(f"{r.url}")
-                        logger.error(f"{json}")
-                        raise RuntimeError
-
-                    gdfs.append(gdf)
-                    pb.update()
-
-    gdf = pd.concat(gdfs)
-    if len(gdf) != metadata['total_records']:
-        logger.error(f"Number of records do not match. Expected {metadata['total_records']}, downloaded: {len(gdf)}")
-    
-    gdf = gdf.set_crs(CRS)
-
-    return gdf
-
-def schema(url, outfields=None):
-    """Extracts the schema from a JSON object returned by an ArcGIS REST API service.
-
-    Parameters:
-    -----------
-    url : str
-        The URL of the ArcGIS REST API service.
-    Returns:
-    --------
-    schema : dict
-        A dictionary containing the schema of the fields in the service.
-    """
-    import frictionless
-    import requests
-
-
-        # Fetch the service metadata
-    logger.info(f"Fetching metadata for schema from {url}?f=pjson")
-    r = requests.get(f"{url}?f=pjson")
-    pjson = r.json()
-    r.close()
-
-    schema = {}
-    schema['fields'] = []
-    if outfields == '*':
-        for field in pjson['fields']:
-            properties = {}
-            properties['name'] = field['name']
-            properties['title'] = field['alias']
-            ftype = field['type'].replace('esriFieldType', '').lower()
-            if ftype == 'oid':
-                properties['type'] ='string'
-            if ftype == 'double':
-                properties['type'] ='number'
-            if ftype == 'single':
-                ftype ='number'
-            if ftype == 'smallinteger':
-                properties['type'] ='number'
-            if ftype == 'geometry':
-                continue # skip extra geometry columns
-            schema['fields'].append(properties)
-    else:
-        for field in pjson['fields']:
-            if field['name'] in outfields.split(','):
-                properties = {}
-                properties['name'] = field['name']
-                properties['title'] = field['alias']
-                ftype = field['type'].replace('esriFieldType', '').lower()
-                if ftype == 'oid':
-                    properties['type'] ='string'
-                if ftype == 'double':
-                    properties['type'] ='number'
-                if ftype == 'single':
-                    ftype ='number'
-                if ftype == 'smallinteger':
-                    properties['type'] ='number'
-                if ftype == 'geometry':
-                    continue # skip extra geometry columns
-                schema['fields'].append(properties)
-
-    return schema
-
-def totalRecordCount(url, **kwargs):
-    """Fetches the total number of records from an ArcGIS REST API service.
-    Parameters:
-    -----------
-    url : str
-        The URL of the ArcGIS REST API service.
-    Returns:
-    --------    
-    total_count : int
-        The total number of records in the service.
-    """
-    import requests
-    import re
-    from morpc.req import get_json_safely
-
-    # Find the total number of records
-    logger.info(f"Requesting metadata for total record")
-
-    # Create query for total record count
-    url= f"{url}/query/"
-    params={}
-    for k, v in kwargs.items():
-        params.update({k: v})
-    params.update({"returnCountOnly": "true"}) ## Inlcude in paramters to return only the total records
-    
-    # Try to fetch it as a geojson
-    try:
-        json = get_json_safely(url, params = params)
-
-    # If it errors, check if geojson is not supported and try json
-    except HTTPError as e:
         try:
-            logger.warning(f"geoJSON not supported, trying Json...")
+            total_record_count = _total_record_count(url, **query)
+        except HTTPError as e:
+            logger.error(f"Failed to get total record count, HTTPError: {e}")
+            raise
+
+        logger.info(f"Total number of geographies: {total_record_count}")
+
+        if max_record_count is None:
+            try:
+                max_record_count = _max_record_count(url)
+            except (ValueError, KeyError):
+                logger.warning("Unable to find maxRecordCount. Using default.")
+                max_record_count = min(total_record_count, 500)
+            logger.info(f"Fetching {max_record_count} at a time.")
+
+        descriptor = {
+            "name": re.sub(r'[:/_ ]', '-', name).lower(),
+            "format": "json",
+            "path": url,
+            "schema": ArcGISSchema.from_url(url, outfields=outfields).to_descriptor(),
+            "mediatype": "application/geo+json",
+            "_metadata": {
+                "type": "arcgis_service",
+                "params": query,
+                "total_records": total_record_count,
+                "max_record_count": max_record_count,
+            },
+        }
+
+        return cls(descriptor)
+
+    def to_geodataframe(self, out_fields: list[str] | None = None, CRS='epsg:4326'):
+        """Fetch all features from the ArcGIS service as a GeoDataFrame.
+
+        Parameters
+        ----------
+        out_fields : list[str], optional
+            Subset of fields to include. Must be present in the resource schema.
+        CRS : str, optional
+            Coordinate reference system for the output GeoDataFrame.
+        """
+        import enlighten
+        import geopandas as gpd
+        import pandas as pd
+        from requests import Session
+        from time import sleep
+
+        headers = {"User-Agent": "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"}
+
+        if out_fields is not None:
+            for field in out_fields:
+                if field not in self.schema.field_names:
+                    logger.error(f"field {field} not in resource fields: {self.schema.field_names}")
+                    raise ValueError(f"field {field} not in resource fields")
+
+        metadata = self.to_dict()['_metadata']
+
+        urls = []
+        for offset in range(0, metadata['total_records'], metadata['max_record_count']):
+            params = dict(metadata['params'])
+            if out_fields is not None:
+                params['outFields'] = ",".join(out_fields)
+            params['resultRecordCount'] = metadata['max_record_count']
+            params['resultOffset'] = offset
+            urls.append(f"{self.path}/query?" + urllib.parse.urlencode(params, safe="=(),"))
+
+        gdfs = []
+        with Session() as session:
+            with enlighten.Manager() as manager:
+                with manager.counter(total=len(urls), desc='Downloading:', unit='requests') as pb:
+                    for url in urls:
+                        logger.debug(f"Fetching {url}")
+                        r = session.get(url)
+                        while r.status_code != 200:
+                            logger.warning(f"Status Code {r.status_code}, trying again. URL: {r.url}")
+                            if r.status_code == 400 and "Output format not supported" in r.text:
+                                url = url.replace('geojson', 'json').replace('&returnGeometry=true', '')
+                                logger.warning(f"Output format not supported, trying json. {url}")
+                            sleep(1)
+                            r = session.get(url, headers=headers)
+
+                        try:
+                            json_data = r.json()
+                        except JSONDecodeError:
+                            logger.error(f"Failed to decode json. {r.content}")
+                            raise
+
+                        try:
+                            gdf = gpd.GeoDataFrame.from_features(json_data)
+                        except Exception as e:
+                            logger.error(f"Failed to create GeoDataFrame. {e}")
+                            logger.error(f"{r.url}")
+                            logger.error(f"{json_data}")
+                            raise RuntimeError(f"Failed to create GeoDataFrame: {e}")
+
+                        gdfs.append(gdf)
+                        pb.update()
+
+        gdf = pd.concat(gdfs)
+        if len(gdf) != metadata['total_records']:
+            logger.error(f"Record count mismatch. Expected {metadata['total_records']}, got {len(gdf)}")
+
+        return gdf.set_crs(CRS)
+
+
+def _schema(url, outfields=None):
+    """Fetch field definitions from an ArcGIS REST service and return a descriptor dict."""
+    return ArcGISSchema.from_url(url, outfields=outfields).to_descriptor()
+
+
+def _total_record_count(url, **kwargs):
+    """Fetch the total record count from an ArcGIS REST service."""
+    logger.info("Requesting total record count")
+
+    params = {**kwargs, 'returnCountOnly': 'true'}
+
+    try:
+        json_data = get_json_safely(f"{url}/query/", params=params)
+    except HTTPError:
+        try:
+            logger.warning("geoJSON not supported, trying JSON...")
             params['f'] = 'json'
-            json = get_json_safely(url, params = params)
-        except:
+            json_data = get_json_safely(f"{url}/query/", params=params)
+        except HTTPError as e:
             logger.error(f"HTTPError: {e}")
-            raise HTTPError
+            raise
 
-    total_count = int(re.findall('[0-9]+',str(json))[0])
+    import re
+    total_count = int(re.findall(r'[0-9]+', str(json_data))[0])
     logger.info(f"Total records: {total_count}")
-
     return total_count
 
-def maxRecordCount(url):
-    """Fetches the total number of records from an ArcGIS REST API service.
-    Parameters:
-    -----------
-    url : str
-        The URL of the ArcGIS REST API service.
-    Returns:
-    --------    
-    total_count : int
-        The total number of records in the service.
-    """
 
-    from morpc.req import get_json_safely
-    # Find the total number of records
-    logger.info(f"Requesting metadata for max records in query")
-
-    # Get properties json
-    url= f"{url}?f=pjson"
+def _max_record_count(url):
+    """Fetch the maxRecordCount from an ArcGIS REST service."""
+    logger.info("Requesting max record count")
 
     try:
-        json, url = get_json_safely(url, returnurl=True)
-        max_record_count = json['maxRecordCount']
-    except ValueError as e:
-        logger.error('Could not find maxRecordCount in json. revert to default value.')
-        raise ValueError
-    except KeyError as e:
-        logger.error(f"maxRecordCount not in json: {url}")
-    logger.info(f"Total records: {max_record_count}")
+        json_data, fetched_url = get_json_safely(f"{url}?f=pjson", returnurl=True)
+        max_record_count = json_data['maxRecordCount']
+    except ValueError:
+        logger.error("Could not find maxRecordCount in response.")
+        raise
+    except KeyError:
+        logger.error(f"maxRecordCount not in response: {fetched_url}")
+        raise
 
-
+    logger.info(f"Max record count: {max_record_count}")
     return max_record_count
 
+
+# Backward-compatible module-level functions
+
+def resource(name, url, where='1=1', outfields='*', max_record_count=None, **kwargs):
+    """Deprecated: use ArcGISResource.from_url() instead."""
+    return ArcGISResource.from_url(name, url, where=where, outfields=outfields, max_record_count=max_record_count, **kwargs)
+
+def gdf_from_resource(resource, out_fields: list[str] | None = None, CRS='epsg:4326'):
+    """Deprecated: use ArcGISResource.to_geodataframe() instead."""
+    if isinstance(resource, str):
+        resource = ArcGISResource(resource)
+    return resource.to_geodataframe(out_fields=out_fields, CRS=CRS)
+
+def schema(url, outfields=None):
+    """Deprecated: use morpc.rest_api._schema() instead."""
+    return _schema(url, outfields=outfields)
+
+def totalRecordCount(url, **kwargs):
+    """Deprecated: use morpc.rest_api._total_record_count() instead."""
+    return _total_record_count(url, **kwargs)
+
+def maxRecordCount(url):
+    """Deprecated: use morpc.rest_api._max_record_count() instead."""
+    return _max_record_count(url)


### PR DESCRIPTION
## Summary

- Adds `show_progress=True` parameter to `to_geodataframe()`
- When `show_progress=False`, the enlighten counter is not created and the fetch loop runs silently
- Default behavior (`show_progress=True`) is unchanged

## Motivation

`morpc-census` calls `to_geodataframe()` once per geoid chunk inside `_fetch_layer`. Each call was spawning its own ephemeral progress bar (typically `1/1 requests`) that flashed and disappeared, giving no useful overall progress signal. This change lets the caller suppress those per-chunk bars so it can own a single unified bar instead.

## Test plan

- [ ] Confirm `to_geodataframe()` called directly still shows its own bar
- [ ] Confirm `to_geodataframe(show_progress=False)` runs silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)