### PR TITLE
Support loading a SQLite table via frictionless.load_data()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,64 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
 ## Project Overview
 
 `morpc` is a Python library (published to PyPI) providing constants, mappings, and shared functions for MORPC data workflows. Python >=3.10 is required.

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -697,22 +697,19 @@ def write_resource(resource, resourcePath):
 def validate_resource(resourcePath):
     import os
     import frictionless
-    cwd = os.getcwd()
 
-    try:
-        os.chdir(os.path.dirname(os.path.abspath(resourcePath)))
-      
-        logger.info("Validating resource on disk including data and schema (if applicable). This may take some time.")
-        resourceOnDisk = frictionless.Resource(os.path.basename(resourcePath))
-
-        results = resourceOnDisk.validate()
-
-    except Exception as e:
-        os.chdir(cwd)
-        logger.error("An unhandled error occurred while trying to validate the Frictionless resource: {}".format(e))
-        raise RuntimeError
+    with tempWorkingDirectory(os.path.dirname(os.path.abspath(resourcePath))):
+        try:
         
-    os.chdir(cwd)
+            logger.info("Validating resource on disk including data and schema (if applicable). This may take some time.")
+            resourceOnDisk = frictionless.Resource(os.path.basename(resourcePath))
+
+            results = resourceOnDisk.validate()
+
+        except Exception as e:
+            logger.error("An unhandled error occurred while trying to validate the Frictionless resource: {}".format(e))
+            raise RuntimeError
+        
     
     if(results.valid == True):
         logger.info("Resource is valid")
@@ -721,7 +718,7 @@ def validate_resource(resourcePath):
         logger.error(f"Resource is NOT valid. Errors follow. {results}")
         return False
 
-def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False, forceInt64=False, useSchema="default", sheetName=None, layerName=None, driverName=None, lineEnds: Literal['\n', '\b\n'] = '\b\n'):
+def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False, forceInt64=False, useSchema="default", sheetName=None, layerName=None, tableName=None, driverName=None, lineEnds: Literal['\n', '\b\n'] = '\b\n'):
     """Often we want to make a copy of some input data and work with the copy, for example to protect 
     the original data or to create an archival copy of it so that we can replicate the process later.  
     The `load_data()` function simplifies the process of reading the data and 
@@ -754,6 +751,9 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
     layerName : str
         The name of the desired layer in the spatial data file. Required when reading as spatial data file that contains multiple layers, such
         as a GeoPackage.
+    tableName : str
+        The name of the desired table in a SQLite database. Required when reading a SQLite file unless the table name is specified in the
+        resource's SQL control (e.g. one created by create_resource with a frictionless.formats.SqlControl).
     driverName : str
         The driver to use to load spatial data. Typically the driver can be inferred from the file extension, but must be specified
         in some situations including when the data is zipped. See morpc.load_spatial_data for more details.
@@ -860,6 +860,22 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
         data = pd.read_excel(targetData, sheet_name=sheetName)
     elif(dataFileExtension in [".gpkg",".shp",".geojson",".gdb"]):
         data = morpc.load_spatial_data(targetData, layerName=layerName, driverName=driverName)
+    elif(dataFileExtension == ".sqlite"):
+        import sqlite3
+        if(tableName == None):
+            # Fall back to the table name stored in the resource's SQL control, if present.
+            sqlControl = resource.dialect.get_control("sql") if resource.dialect.has_control("sql") else None
+            if(sqlControl != None and sqlControl.table != None):
+                tableName = sqlControl.table
+                logger.info("Table name not specified. Using table name from resource SQL control: {}".format(tableName))
+            else:
+                logger.error("No table name available. Specify tableName or include a SQL control with a table name in the resource.")
+                raise RuntimeError
+        con = sqlite3.connect(targetData)
+        try:
+            data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
+        finally:
+            con.close()
     else:
         logger.error("Unknown data file extension: {}".format(dataFileExtension))
         raise RuntimeError

--- a/tests/test_frictionless.py
+++ b/tests/test_frictionless.py
@@ -1,0 +1,60 @@
+import sqlite3
+
+import pandas as pd
+import pytest
+
+from morpc.frictionless import load_data
+
+
+SCHEMA_YAML = """\
+fields:
+  - name: id
+    type: integer
+  - name: name
+    type: string
+"""
+
+
+def _build_sqlite(dirpath, table="people", include_control=True):
+    """Create a SQLite database plus resource/schema sidecars in dirpath. Returns the resource path."""
+    dataPath = dirpath / "data.sqlite"
+    con = sqlite3.connect(dataPath)
+    df = pd.DataFrame({"id": [1, 2], "name": ["alice", "bob"]})
+    df.to_sql(table, con, index=False)
+    con.close()
+
+    (dirpath / "data.schema.yaml").write_text(SCHEMA_YAML)
+
+    resourceLines = [
+        "name: people",
+        "type: table",
+        "path: data.sqlite",
+        "format: sqlite",
+        "schema: data.schema.yaml",
+    ]
+    if include_control:
+        resourceLines += ["dialect:", "  sql:", f"    table: {table}"]
+    resourcePath = dirpath / "data.resource.yaml"
+    resourcePath.write_text("\n".join(resourceLines) + "\n")
+    return resourcePath
+
+
+def test_load_sqlite_with_table_name(tmp_path):
+    resourcePath = _build_sqlite(tmp_path, table="people", include_control=False)
+    data, resource, schema = load_data(str(resourcePath), tableName="people")
+    assert list(data.columns) == ["id", "name"]
+    assert data["id"].tolist() == [1, 2]
+    assert data["name"].tolist() == ["alice", "bob"]
+    assert pd.api.types.is_integer_dtype(data["id"])
+
+
+def test_load_sqlite_table_name_from_control(tmp_path):
+    resourcePath = _build_sqlite(tmp_path, table="people", include_control=True)
+    data, resource, schema = load_data(str(resourcePath))
+    assert data["name"].tolist() == ["alice", "bob"]
+
+
+def test_load_sqlite_missing_table_name_raises(tmp_path):
+    resourcePath = _build_sqlite(tmp_path, table="people", include_control=False)
+    with pytest.raises(RuntimeError):
+        load_data(str(resourcePath))


### PR DESCRIPTION
## Summary

Adds the ability to read a SQLite table through `morpc.frictionless.load_data()`. Previously a `.sqlite` resource fell through the read dispatch to a `RuntimeError`, even though `create_resource()` already supported writing SQLite resource descriptors.

## Changes

- Add a `tableName=None` parameter to `load_data()` (analogous to `sheetName` for Excel and `layerName` for spatial files), since a SQLite database can hold multiple tables.
- Add a `.sqlite` branch to the read dispatch:
  - Reads the requested table with the stdlib `sqlite3` module + `pandas.read_sql_query` — **no new dependency**.
  - Falls back to the table name stored in the resource's SQL control (`resource.dialect.get_control("sql").table`) when `tableName` isn't passed.
  - Raises a clear `RuntimeError` when no table name can be determined.
  - Result flows through the existing `cast_field_types()` step, so schema typing/validation behave identically to other formats.
- Add `tests/test_frictionless.py` covering the explicit table name, the control fallback, and the missing-table-name error.

This PR also bundles a pre-existing working-tree refactor of `validate_resource()` (to use `tempWorkingDirectory`) and pending `CLAUDE.md` edits.

## Testing

`pytest` — 36 passed.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)