### PR TITLE
Add shell parameter to wget()

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/morpc.py
+++ b/morpc/morpc.py
@@ -1271,7 +1271,7 @@ def avro_cast_field_types(df, schema, forceInteger=False, forceInt64=False, verb
 
     return outDF
 
-def wget(url, archive_dir = './input_data', filename = None, return_filepath=False, verbose=True):
+def wget(url, archive_dir = './input_data', filename = None, return_filepath=False, shell=False, verbose=True):
     """
     This function uses wget within a subprocess call to retrieve a file from an ftp site. This is used as a means of retrieving Census TigerLine shapefiles.
 
@@ -1289,6 +1289,9 @@ def wget(url, archive_dir = './input_data', filename = None, return_filepath=Fal
     return_filepath : boolean
         If True, returns the filepath of the saved file.
 
+    shell : boolean
+        If True, runs the subprocess command through the shell. Defaults to False.
+
     """
     import subprocess
     import os
@@ -1303,7 +1306,7 @@ def wget(url, archive_dir = './input_data', filename = None, return_filepath=Fal
         os.mkdir(archive_dir)
 
     try:
-        results = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        results = subprocess.run(cmd, check=True, capture_output=True, text=True, shell=shell)
         if verbose:
             print(results.stdout)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- Add a `shell` parameter to `morpc.wget()` that is passed through to the `subprocess.run()` call (defaults to `False`, preserving existing behavior).
- Document the new parameter in the function docstring.
- Bump version to 0.5.6.

## Why
Allows callers to run the underlying `wget` command through the shell when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)