### PR TITLE
Add curl() function mirroring wget()

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/morpc.py
+++ b/morpc/morpc.py
@@ -1317,6 +1317,52 @@ def wget(url, archive_dir = './input_data', filename = None, return_filepath=Fal
     if return_filepath:
         return os.path.normpath(f'./{archive_dir}/{filename}')
 
+def curl(url, archive_dir = './input_data', filename = None, return_filepath=False, shell=False, verbose=True):
+    """
+    This function uses curl within a subprocess call to retrieve a file from an ftp site. This is used as a means of retrieving Census TigerLine shapefiles.
+
+    Parameters
+    ----------
+    url : string
+        The url for the location of the file.
+
+    archive_dir : string, path like
+        The location to save the file.
+
+    filename : string
+        Optional: filename for archived file
+
+    return_filepath : boolean
+        If True, returns the filepath of the saved file.
+
+    shell : boolean
+        If True, runs the subprocess command through the shell. Defaults to False.
+
+    """
+    import subprocess
+    import os
+
+    if not filename:
+        filename = os.path.basename(url)
+
+    cmd = ['curl', url]
+    cmd.extend(['-o', os.path.normpath(f'./{archive_dir}/{filename}')])
+
+    if not os.path.exists(archive_dir):
+        os.mkdir(archive_dir)
+
+    try:
+        results = subprocess.run(cmd, check=True, capture_output=True, text=True, shell=shell)
+        if verbose:
+            print(results.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to download file: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+
+    if return_filepath:
+        return os.path.normpath(f'./{archive_dir}/{filename}')
+
 
 
 # Load spatial data

--- a/tests/test_morpc.py
+++ b/tests/test_morpc.py
@@ -1,0 +1,101 @@
+import os
+import subprocess
+
+import pytest
+
+import morpc
+
+
+class FakeCompleted:
+    def __init__(self):
+        self.stdout = ""
+        self.stderr = ""
+
+
+def test_curl_builds_expected_command(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        calls['cmd'] = cmd
+        calls['kwargs'] = kwargs
+        return FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    archive_dir = str(tmp_path / "input_data")
+    morpc.curl("https://example.com/file.zip", archive_dir=archive_dir, verbose=False)
+
+    expected_path = os.path.normpath(f'./{archive_dir}/file.zip')
+    assert calls['cmd'] == ['curl', 'https://example.com/file.zip', '-o', expected_path]
+    assert calls['kwargs']['shell'] is False
+    assert calls['kwargs']['check'] is True
+
+
+def test_curl_shell_passthrough(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        calls['kwargs'] = kwargs
+        return FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    morpc.curl("https://example.com/file.zip", archive_dir=str(tmp_path / "d"), shell=True, verbose=False)
+    assert calls['kwargs']['shell'] is True
+
+
+def test_curl_uses_basename_when_no_filename(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        calls['cmd'] = cmd
+        return FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    archive_dir = str(tmp_path / "d")
+    morpc.curl("https://example.com/data/tiger.shp", archive_dir=archive_dir, verbose=False)
+    assert calls['cmd'][-1] == os.path.normpath(f'./{archive_dir}/tiger.shp')
+
+
+def test_curl_custom_filename(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(cmd, **kwargs):
+        calls['cmd'] = cmd
+        return FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    archive_dir = str(tmp_path / "d")
+    morpc.curl("https://example.com/file.zip", archive_dir=archive_dir, filename="renamed.zip", verbose=False)
+    assert calls['cmd'][-1] == os.path.normpath(f'./{archive_dir}/renamed.zip')
+
+
+def test_curl_creates_archive_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **kwargs: FakeCompleted())
+
+    archive_dir = tmp_path / "newdir"
+    assert not archive_dir.exists()
+    morpc.curl("https://example.com/file.zip", archive_dir=str(archive_dir), verbose=False)
+    assert archive_dir.exists()
+
+
+def test_curl_return_filepath(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **kwargs: FakeCompleted())
+
+    archive_dir = str(tmp_path / "d")
+    result = morpc.curl(
+        "https://example.com/file.zip",
+        archive_dir=archive_dir,
+        return_filepath=True,
+        verbose=False,
+    )
+    assert result == os.path.normpath(f'./{archive_dir}/file.zip')
+
+
+def test_curl_no_return_by_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **kwargs: FakeCompleted())
+
+    result = morpc.curl("https://example.com/file.zip", archive_dir=str(tmp_path / "d"), verbose=False)
+    assert result is None


### PR DESCRIPTION
## Summary
- Add a `curl()` function to the `morpc` module that mirrors `wget()`, using `curl <url> -o <filepath>` instead of `wget <url> -O <filepath>`. Same signature, including the `shell` parameter.
- Add `tests/test_morpc.py` with tests covering command construction, `shell` passthrough, filename handling (URL basename and override), archive-dir creation, and return value. `subprocess.run` is mocked, so no network calls.
- Bump version to 0.5.7.

## Why
Provides a curl-based download helper for environments where curl is preferred or wget is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)