### PR TITLE
Select schema fields and restore case when loading SQLite

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.7"
+__version__ = "0.5.8"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -757,7 +757,7 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
     driverName : str
         The driver to use to load spatial data. Typically the driver can be inferred from the file extension, but must be specified
         in some situations including when the data is zipped. See morpc.load_spatial_data for more details.
-    lineEnds : ['unix', 'dos']
+    lineEnds : ['\n', '\b\n']
         The type of line end separator to use for the data. If does not match, try to convert. Defaults to '\b\n'
 
     Returns
@@ -873,7 +873,24 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
                 raise RuntimeError
         con = sqlite3.connect(targetData)
         try:
-            data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
+            if(schema == None):
+                data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
+            else:
+                # SQLite stores column names in lowercase while Frictionless schemas often use camelCase.
+                # Select only the fields described by the schema (matching column names case-insensitively)
+                # and restore each column to the casing used in the schema.
+                actualColumns = pd.read_sql_query('SELECT * FROM "{}" LIMIT 0'.format(tableName), con).columns
+                lowerToActual = {column.lower(): column for column in actualColumns}
+                renameMap = {}
+                for field in schema.fields:
+                    actualColumn = lowerToActual.get(field.name.lower())
+                    if(actualColumn == None):
+                        logger.error("Schema field '{}' not found in SQLite table '{}'.".format(field.name, tableName))
+                        raise RuntimeError
+                    renameMap[actualColumn] = field.name
+                columnList = ", ".join('"{}"'.format(column) for column in renameMap)
+                data = pd.read_sql_query('SELECT {} FROM "{}"'.format(columnList, tableName), con)
+                data = data.rename(columns=renameMap)
         finally:
             con.close()
     else:

--- a/tests/test_frictionless.py
+++ b/tests/test_frictionless.py
@@ -58,3 +58,62 @@ def test_load_sqlite_missing_table_name_raises(tmp_path):
     resourcePath = _build_sqlite(tmp_path, table="people", include_control=False)
     with pytest.raises(RuntimeError):
         load_data(str(resourcePath))
+
+
+CAMEL_SCHEMA_YAML = """\
+fields:
+  - name: personId
+    type: integer
+  - name: fullName
+    type: string
+"""
+
+
+def _build_sqlite_camel(dirpath, table="people"):
+    """SQLite with lowercase columns plus an extra column, paired with a camelCase schema."""
+    dataPath = dirpath / "data.sqlite"
+    con = sqlite3.connect(dataPath)
+    df = pd.DataFrame({
+        "personid": [1, 2],
+        "fullname": ["alice", "bob"],
+        "extra": ["x", "y"],
+    })
+    df.to_sql(table, con, index=False)
+    con.close()
+
+    (dirpath / "data.schema.yaml").write_text(CAMEL_SCHEMA_YAML)
+    resourcePath = dirpath / "data.resource.yaml"
+    resourcePath.write_text("\n".join([
+        "name: people",
+        "type: table",
+        "path: data.sqlite",
+        "format: sqlite",
+        "schema: data.schema.yaml",
+    ]) + "\n")
+    return resourcePath
+
+
+def test_load_sqlite_restores_schema_case_and_selects_schema_fields(tmp_path):
+    resourcePath = _build_sqlite_camel(tmp_path, table="people")
+    data, resource, schema = load_data(str(resourcePath), tableName="people")
+    # Only the schema fields are returned, with the schema's camelCase restored.
+    assert list(data.columns) == ["personId", "fullName"]
+    assert "extra" not in data.columns
+    assert data["personId"].tolist() == [1, 2]
+    assert data["fullName"].tolist() == ["alice", "bob"]
+    assert pd.api.types.is_integer_dtype(data["personId"])
+
+
+def test_load_sqlite_no_schema_returns_all_columns(tmp_path):
+    resourcePath = _build_sqlite_camel(tmp_path, table="people")
+    data, resource, schema = load_data(str(resourcePath), tableName="people", useSchema=None)
+    # With no schema, all columns are returned as-is.
+    assert list(data.columns) == ["personid", "fullname", "extra"]
+
+
+def test_load_sqlite_schema_field_missing_from_table_raises(tmp_path):
+    resourcePath = _build_sqlite_camel(tmp_path, table="people")
+    # Schema references a field that does not exist in the SQLite table.
+    (tmp_path / "data.schema.yaml").write_text(CAMEL_SCHEMA_YAML + "  - name: missingField\n    type: string\n")
+    with pytest.raises(RuntimeError):
+        load_data(str(resourcePath), tableName="people")


### PR DESCRIPTION
## Summary
- When `frictionless.load_data()` reads a SQLite table and a schema is in use, select **only** the fields described by the schema rather than `SELECT *`.
- SQLite stores column names in lowercase while Frictionless schemas often use camelCase, so columns are matched case-insensitively and renamed back to the schema's casing.
- If a schema field has no matching column in the table, log an error and raise `RuntimeError`.
- Behavior is unchanged when `useSchema=None` (still returns all columns as stored).
- Bump version to 0.5.8.

## Tests
Added to `tests/test_frictionless.py`:
- camelCase schema over lowercase SQLite columns → columns restored to schema case, non-schema column dropped, integer dtype applied
- `useSchema=None` → all columns returned as-is
- schema field missing from table → `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)