### PR TITLE
Add SQLite support and CRS handling to load_spatial_data()

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/morpc.py
+++ b/morpc/morpc.py
@@ -1366,7 +1366,7 @@ def curl(url, archive_dir = './input_data', filename = None, return_filepath=Fal
 
 
 # Load spatial data
-def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=None, archiveFileName=None, verbose=True):
+def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=None, archiveFileName=None, geometryColumn="geom", targetCRS=None, verbose=True):
     """Often we want to make a copy of some input data and work with the copy, for example to protect 
     the original data or to create an archival copy of it so that we can replicate the process later.  
     With tabular data this is simple, but with spatial data it can be tricky.  Shapefiles actually consist 
@@ -1383,9 +1383,9 @@ def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=No
         point to the .shp file or a zipped file that contains all of the Shapefile components. You can point to 
         other zipped contents as well, but see caveats below.
     layerName : str
-        Required for GPKG and GDB, optional for SHP. The name of the layer that you wish to extract from a 
-        GeoPackage or File Geodatabase.  Not required for Shapefiles, but may be specified for use in the 
-        archival copy (see below)
+        Required for GPKG, GDB, and SQLite, optional for SHP. The name of the layer that you wish to extract from a
+        GeoPackage or File Geodatabase, or the name of the table for a SQLite database.  Not required for Shapefiles,
+        but may be specified for use in the archival copy (see below)
     driverName : str
         Required for zipped data or data with non-standard file extension. Which GDAL driver
         (https://gdal.org/drivers/vector/index.html) to use to read the file. Script will attempt to infer 
@@ -1396,9 +1396,15 @@ def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=No
         the data will be archived in this location as a GeoPackage.  The function will determine the file name 
         and layer name from the specified parameters, using generic values if necessary.
     archiveFileName : str
-        Optional. If `archiveDir` is specified, you may use this to specify the name of the archival GeoPackage.  
-        Omit the extension.  If this is unspecified, the function will assign the file name automatically using a 
+        Optional. If `archiveDir` is specified, you may use this to specify the name of the archival GeoPackage.
+        Omit the extension.  If this is unspecified, the function will assign the file name automatically using a
         generic value if necessary.
+    geometryColumn : str
+        Optional. The name of the geometry column. Used when reading a SQLite database. Defaults to "geom".
+    targetCRS : str
+        Optional. The coordinate reference system to reproject the geometry to, applied to all file types via
+        to_crs(). If None (the default), the data's native CRS is returned without reprojection. SQLite WKB geometry
+        carries no CRS information, so it is assumed to be "epsg:4326" on read.
     verbose : bool
         Set verbose to False to reduce the text output from the function.
 
@@ -1429,6 +1435,8 @@ def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=No
             driverName = "ESRI Shapefile"
         elif(fileExt == ".gdb"):
             driverName = "OpenFileGDB"
+        elif(fileExt == ".sqlite"):
+            driverName = "SQLite"
         else:
             logger.error("File extension is unsupported: {}.  It is possible to load zipped spatial data, but you must specify the driver name.".format(fileExt))
             raise RuntimeError
@@ -1439,7 +1447,7 @@ def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=No
             logger.info("Using driver {} as specified by user.".format(driverName))
 
     if(layerName) == None:
-        if(driverName == "GPKG" or driverName == "OpenFileGDB"):
+        if(driverName == "GPKG" or driverName == "OpenFileGDB" or driverName == "SQLite"):
             logger.error("Must specify layerName when using driver {}".format(driverName))
             raise RuntimeError
 
@@ -1448,9 +1456,22 @@ def load_spatial_data(sourcePath, layerName=None, driverName=None, archiveDir=No
     # Geopandas will throw an error if we attempt to specify a layer name when reading a Shapefile
     if(driverName == "ESRI Shapefile"):
         gdf = gpd.read_file(sourcePath, layer=None, engine="pyogrio", fid_as_index=True)
+    # SQLite databases are read via read_postgis, treating layerName as the table name and geometryColumn as the geometry column.
+    # WKB geometry carries no CRS, so assume epsg:4326 on read.
+    elif(driverName == "SQLite"):
+        import sqlite3
+        con = sqlite3.connect(sourcePath)
+        try:
+            gdf = gpd.read_postgis('SELECT * FROM "{}"'.format(layerName), con, geom_col=geometryColumn, crs="epsg:4326")
+        finally:
+            con.close()
     # Everything else
     else:
         gdf = gpd.read_file(sourcePath, layer=layerName, engine="pyogrio", fid_as_index=True)
+
+    # Reproject to the target CRS if one was specified; otherwise return the native CRS
+    if(targetCRS != None):
+        gdf = gdf.to_crs(targetCRS)
 
     # If the user has specified an archive directory, create an archival copy of the data as a layer in a GeoPackage
     if(archiveDir != None):

--- a/tests/test_morpc.py
+++ b/tests/test_morpc.py
@@ -99,3 +99,53 @@ def test_curl_no_return_by_default(monkeypatch, tmp_path):
 
     result = morpc.curl("https://example.com/file.zip", archive_dir=str(tmp_path / "d"), verbose=False)
     assert result is None
+
+
+# --- load_spatial_data: SQLite support ---
+
+def _build_spatial_sqlite(dirpath, table="parcels", geom_column="geom"):
+    """Create a SQLite database with a WKB geometry column. Returns the file path."""
+    import sqlite3
+    from shapely.geometry import Point
+
+    dataPath = dirpath / "data.sqlite"
+    con = sqlite3.connect(dataPath)
+    con.execute(f'CREATE TABLE "{table}" (id INTEGER, "{geom_column}" BLOB)')
+    con.executemany(
+        f'INSERT INTO "{table}" (id, "{geom_column}") VALUES (?, ?)',
+        [(1, Point(0, 0).wkb), (2, Point(1, 1).wkb)],
+    )
+    con.commit()
+    con.close()
+    return dataPath
+
+
+def test_load_spatial_data_sqlite(tmp_path):
+    import geopandas as gpd
+
+    dataPath = _build_spatial_sqlite(tmp_path, table="parcels")
+    gdf = morpc.load_spatial_data(str(dataPath), layerName="parcels", verbose=False)
+    assert isinstance(gdf, gpd.GeoDataFrame)
+    assert gdf["id"].tolist() == [1, 2]
+    assert list(gdf.geometry.geom_type) == ["Point", "Point"]
+    assert (gdf.geometry.x.tolist(), gdf.geometry.y.tolist()) == ([0.0, 1.0], [0.0, 1.0])
+    # CRS defaults to epsg:4326
+    assert gdf.crs == "epsg:4326"
+
+
+def test_load_spatial_data_sqlite_requires_layer_name(tmp_path):
+    dataPath = _build_spatial_sqlite(tmp_path, table="parcels")
+    with pytest.raises(RuntimeError):
+        morpc.load_spatial_data(str(dataPath), verbose=False)
+
+
+def test_load_spatial_data_sqlite_custom_geometry_column(tmp_path):
+    dataPath = _build_spatial_sqlite(tmp_path, table="parcels", geom_column="shape")
+    gdf = morpc.load_spatial_data(str(dataPath), layerName="parcels", geometryColumn="shape", verbose=False)
+    assert list(gdf.geometry.geom_type) == ["Point", "Point"]
+
+
+def test_load_spatial_data_sqlite_custom_target_crs(tmp_path):
+    dataPath = _build_spatial_sqlite(tmp_path, table="parcels")
+    gdf = morpc.load_spatial_data(str(dataPath), layerName="parcels", targetCRS="epsg:3735", verbose=False)
+    assert gdf.crs == "epsg:3735"


### PR DESCRIPTION
## Summary
- Add `.sqlite` support to `morpc.load_spatial_data()`, read via `geopandas.read_postgis()` with `layerName` as the table name.
- Add a `geometryColumn` parameter (default `"geom"`) for the SQLite geometry column.
- Add a `targetCRS` parameter (default `None`):
  - When `None`, the data's native CRS is returned (no behavior change for shp/gpkg/gdb).
  - When set, all file types are reprojected to it via `to_crs()`.
- SQLite WKB carries no CRS, so it is tagged `epsg:4326` on read (via `read_postgis`'s `crs=`), then reprojected only if `targetCRS` is provided.
- Bump version to 0.5.9.

## Tests
Added to `tests/test_morpc.py`:
- Load a SQLite table with a WKB geometry column → GeoDataFrame with expected points and `epsg:4326`
- Custom `geometryColumn`
- Custom `targetCRS` reprojects
- Missing `layerName` raises `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)