### PR TITLE
Load spatial SQLite via geopandas in load_data()

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.9"
+__version__ = "0.5.10"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -718,7 +718,34 @@ def validate_resource(resourcePath):
         logger.error(f"Resource is NOT valid. Errors follow. {results}")
         return False
 
-def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False, forceInt64=False, useSchema="default", sheetName=None, layerName=None, tableName=None, driverName=None, lineEnds: Literal['\n', '\b\n'] = '\b\n'):
+def _detect_sqlite_geometry_column(con, tableName):
+    """Return the name of the geometry column in a SQLite table, or None if there is none.
+
+    Spatial SQLite tables produced for MORPC workflows store geometry as raw WKB in a BLOB column with no
+    accompanying metadata to distinguish it from an ordinary BLOB. We identify the geometry column by sampling
+    each column's first non-null value and checking whether it parses as WKB.
+    """
+    import pandas as pd
+    import shapely.wkb
+
+    columns = pd.read_sql_query('SELECT * FROM "{}" LIMIT 0'.format(tableName), con).columns
+    cursor = con.cursor()
+    for column in columns:
+        row = cursor.execute('SELECT "{}" FROM "{}" WHERE "{}" IS NOT NULL LIMIT 1'.format(column, tableName, column)).fetchone()
+        if(row == None):
+            continue
+        value = row[0]
+        if(not isinstance(value, (bytes, bytearray))):
+            continue
+        try:
+            shapely.wkb.loads(bytes(value))
+            return column
+        except Exception:
+            continue
+    return None
+
+
+def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False, forceInt64=False, useSchema="default", sheetName=None, layerName=None, tableName=None, driverName=None, targetCRS=None, lineEnds: Literal['\n', '\b\n'] = '\b\n'):
     """Often we want to make a copy of some input data and work with the copy, for example to protect 
     the original data or to create an archival copy of it so that we can replicate the process later.  
     The `load_data()` function simplifies the process of reading the data and 
@@ -757,6 +784,10 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
     driverName : str
         The driver to use to load spatial data. Typically the driver can be inferred from the file extension, but must be specified
         in some situations including when the data is zipped. See morpc.load_spatial_data for more details.
+    targetCRS : str
+        Optional. The coordinate reference system to reproject the geometry to when loading a spatial SQLite database. Only used
+        when a geometry column is detected in a SQLite file. SQLite WKB geometry carries no CRS information, so it is assumed to be
+        "epsg:4326" on read. If None (the default), the data's native CRS is returned without reprojection. See morpc.load_spatial_data.
     lineEnds : ['\n', '\b\n']
         The type of line end separator to use for the data. If does not match, try to convert. Defaults to '\b\n'
 
@@ -873,26 +904,39 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
                 raise RuntimeError
         con = sqlite3.connect(targetData)
         try:
-            if(schema == None):
-                data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
-            else:
-                # SQLite stores column names in lowercase while Frictionless schemas often use camelCase.
-                # Select only the fields described by the schema (matching column names case-insensitively)
-                # and restore each column to the casing used in the schema.
-                actualColumns = pd.read_sql_query('SELECT * FROM "{}" LIMIT 0'.format(tableName), con).columns
-                lowerToActual = {column.lower(): column for column in actualColumns}
-                renameMap = {}
-                for field in schema.fields:
-                    actualColumn = lowerToActual.get(field.name.lower())
-                    if(actualColumn == None):
-                        logger.error("Schema field '{}' not found in SQLite table '{}'.".format(field.name, tableName))
-                        raise RuntimeError
-                    renameMap[actualColumn] = field.name
-                columnList = ", ".join('"{}"'.format(column) for column in renameMap)
-                data = pd.read_sql_query('SELECT {} FROM "{}"'.format(columnList, tableName), con)
-                data = data.rename(columns=renameMap)
+            # A spatial SQLite database stores geometry as raw WKB in a BLOB column with no metadata to
+            # distinguish it. Detect such a column by parsing a sample value as WKB. If one is found, defer
+            # to morpc.load_spatial_data() which reads the table as a GeoDataFrame.
+            geometryColumn = _detect_sqlite_geometry_column(con, tableName)
         finally:
             con.close()
+
+        if(geometryColumn != None):
+            logger.info("Detected geometry column '{}' in SQLite table '{}'. Loading as spatial data.".format(geometryColumn, tableName))
+            data = morpc.load_spatial_data(targetData, layerName=tableName, driverName="SQLite", geometryColumn=geometryColumn, targetCRS=targetCRS)
+        else:
+            con = sqlite3.connect(targetData)
+            try:
+                if(schema == None):
+                    data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
+                else:
+                    # SQLite stores column names in lowercase while Frictionless schemas often use camelCase.
+                    # Select only the fields described by the schema (matching column names case-insensitively)
+                    # and restore each column to the casing used in the schema.
+                    actualColumns = pd.read_sql_query('SELECT * FROM "{}" LIMIT 0'.format(tableName), con).columns
+                    lowerToActual = {column.lower(): column for column in actualColumns}
+                    renameMap = {}
+                    for field in schema.fields:
+                        actualColumn = lowerToActual.get(field.name.lower())
+                        if(actualColumn == None):
+                            logger.error("Schema field '{}' not found in SQLite table '{}'.".format(field.name, tableName))
+                            raise RuntimeError
+                        renameMap[actualColumn] = field.name
+                    columnList = ", ".join('"{}"'.format(column) for column in renameMap)
+                    data = pd.read_sql_query('SELECT {} FROM "{}"'.format(columnList, tableName), con)
+                    data = data.rename(columns=renameMap)
+            finally:
+                con.close()
     else:
         logger.error("Unknown data file extension: {}".format(dataFileExtension))
         raise RuntimeError

--- a/tests/test_frictionless.py
+++ b/tests/test_frictionless.py
@@ -117,3 +117,80 @@ def test_load_sqlite_schema_field_missing_from_table_raises(tmp_path):
     (tmp_path / "data.schema.yaml").write_text(CAMEL_SCHEMA_YAML + "  - name: missingField\n    type: string\n")
     with pytest.raises(RuntimeError):
         load_data(str(resourcePath), tableName="people")
+
+
+# --- load_data: spatial SQLite support ---
+
+SPATIAL_SCHEMA_YAML = """\
+fields:
+  - name: id
+    type: integer
+"""
+
+
+def _build_spatial_sqlite_resource(dirpath, table="parcels", geom_column="geom", include_control=True):
+    """Create a spatial SQLite database (WKB BLOB geometry) plus resource/schema sidecars. Returns the resource path."""
+    from shapely.geometry import Point
+
+    dataPath = dirpath / "data.sqlite"
+    con = sqlite3.connect(dataPath)
+    con.execute(f'CREATE TABLE "{table}" (id INTEGER, "{geom_column}" BLOB)')
+    con.executemany(
+        f'INSERT INTO "{table}" (id, "{geom_column}") VALUES (?, ?)',
+        [(1, Point(0, 0).wkb), (2, Point(1, 1).wkb)],
+    )
+    con.commit()
+    con.close()
+
+    (dirpath / "data.schema.yaml").write_text(SPATIAL_SCHEMA_YAML)
+
+    resourceLines = [
+        "name: parcels",
+        "type: table",
+        "path: data.sqlite",
+        "format: sqlite",
+        "schema: data.schema.yaml",
+    ]
+    if include_control:
+        resourceLines += ["dialect:", "  sql:", f"    table: {table}"]
+    resourcePath = dirpath / "data.resource.yaml"
+    resourcePath.write_text("\n".join(resourceLines) + "\n")
+    return resourcePath
+
+
+def test_load_data_spatial_sqlite_detects_geometry(tmp_path):
+    import geopandas as gpd
+
+    resourcePath = _build_spatial_sqlite_resource(tmp_path, table="parcels")
+    data, resource, schema = load_data(str(resourcePath))
+    assert isinstance(data, gpd.GeoDataFrame)
+    assert data["id"].tolist() == [1, 2]
+    assert list(data.geometry.geom_type) == ["Point", "Point"]
+    assert pd.api.types.is_integer_dtype(data["id"])
+    # WKB geometry carries no CRS, so epsg:4326 is assumed on read.
+    assert data.crs == "epsg:4326"
+
+
+def test_load_data_spatial_sqlite_custom_geometry_column(tmp_path):
+    import geopandas as gpd
+
+    resourcePath = _build_spatial_sqlite_resource(tmp_path, table="parcels", geom_column="shape")
+    data, resource, schema = load_data(str(resourcePath), tableName="parcels")
+    assert isinstance(data, gpd.GeoDataFrame)
+    assert list(data.geometry.geom_type) == ["Point", "Point"]
+
+
+def test_load_data_spatial_sqlite_target_crs(tmp_path):
+    resourcePath = _build_spatial_sqlite_resource(tmp_path, table="parcels")
+    data, resource, schema = load_data(str(resourcePath), targetCRS="epsg:3735")
+    assert data.crs == "epsg:3735"
+
+
+def test_load_data_nonspatial_sqlite_returns_plain_dataframe(tmp_path):
+    import geopandas as gpd
+
+    # A SQLite file with no WKB geometry column must still load as an ordinary DataFrame.
+    resourcePath = _build_sqlite(tmp_path, table="people", include_control=True)
+    data, resource, schema = load_data(str(resourcePath))
+    assert not isinstance(data, gpd.GeoDataFrame)
+    assert data["name"].tolist() == ["alice", "bob"]


### PR DESCRIPTION
## Summary
`frictionless.load_data()` now auto-detects spatial SQLite resources and loads them as a GeoDataFrame, while the tabular SQLite path stays unchanged.

- **New helper `_detect_sqlite_geometry_column()`** — spatial SQLite tables store geometry as raw WKB in a BLOB column with no `geometry_columns` metadata, so detection samples each column's first non-null value and treats the one that parses as WKB (`shapely.wkb.loads`) as the geometry column.
- **`.sqlite` branch in `load_data()`** — when a geometry column is detected, loading is delegated to the existing `morpc.load_spatial_data(..., driverName="SQLite", ...)`, returning a GeoDataFrame; otherwise the original `pd.read_sql_query` tabular path runs unchanged.
- **New `targetCRS` passthrough** — WKB carries no CRS, so `epsg:4326` is assumed on read; `targetCRS` enables optional reprojection. Docstring updated.

This reuses `load_spatial_data()` rather than duplicating `read_postgis` logic. Schema casting via `cast_field_types` runs afterward and leaves the geometry column intact (it's not a schema field), consistent with the `.gpkg`/`.shp` path.

## Tests
4 new tests in `tests/test_frictionless.py`: geometry auto-detection (GeoDataFrame + `epsg:4326`), custom geometry column name, `targetCRS` reprojection, and a non-spatial regression case. `pytest tests/test_frictionless.py` → 10 passed.

## Release
Bumps `__version__` to `0.5.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)