### PR TITLE
Apply SQLite field-name correction for spatial and tabular loads

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -917,26 +917,31 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
         else:
             con = sqlite3.connect(targetData)
             try:
-                if(schema == None):
-                    data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
-                else:
-                    # SQLite stores column names in lowercase while Frictionless schemas often use camelCase.
-                    # Select only the fields described by the schema (matching column names case-insensitively)
-                    # and restore each column to the casing used in the schema.
-                    actualColumns = pd.read_sql_query('SELECT * FROM "{}" LIMIT 0'.format(tableName), con).columns
-                    lowerToActual = {column.lower(): column for column in actualColumns}
-                    renameMap = {}
-                    for field in schema.fields:
-                        actualColumn = lowerToActual.get(field.name.lower())
-                        if(actualColumn == None):
-                            logger.error("Schema field '{}' not found in SQLite table '{}'.".format(field.name, tableName))
-                            raise RuntimeError
-                        renameMap[actualColumn] = field.name
-                    columnList = ", ".join('"{}"'.format(column) for column in renameMap)
-                    data = pd.read_sql_query('SELECT {} FROM "{}"'.format(columnList, tableName), con)
-                    data = data.rename(columns=renameMap)
+                data = pd.read_sql_query('SELECT * FROM "{}"'.format(tableName), con)
             finally:
                 con.close()
+
+        # SQLite stores column names in lowercase while Frictionless schemas often use camelCase. Now that
+        # the data is loaded (whether as a tabular DataFrame or a spatial GeoDataFrame), select only the
+        # fields described by the schema (matching column names case-insensitively) and restore each column
+        # to the casing used in the schema. For spatial data, the geometry column is retained and renamed
+        # to "geometry".
+        if(schema != None):
+            lowerToActual = {column.lower(): column for column in data.columns}
+            renameMap = {}
+            for field in schema.fields:
+                actualColumn = lowerToActual.get(field.name.lower())
+                if(actualColumn == None):
+                    logger.error("Schema field '{}' not found in SQLite table '{}'.".format(field.name, tableName))
+                    raise RuntimeError
+                renameMap[actualColumn] = field.name
+            keepColumns = list(renameMap.keys())
+            if(geometryColumn != None):
+                renameMap[geometryColumn] = "geometry"
+                keepColumns.append(geometryColumn)
+            data = data[keepColumns].rename(columns=renameMap)
+            if(geometryColumn != None):
+                data = data.set_geometry("geometry")
     else:
         logger.error("Unknown data file extension: {}".format(dataFileExtension))
         raise RuntimeError

--- a/tests/test_frictionless.py
+++ b/tests/test_frictionless.py
@@ -164,6 +164,9 @@ def test_load_data_spatial_sqlite_detects_geometry(tmp_path):
     resourcePath = _build_spatial_sqlite_resource(tmp_path, table="parcels")
     data, resource, schema = load_data(str(resourcePath))
     assert isinstance(data, gpd.GeoDataFrame)
+    # The geometry column is renamed to "geometry" and remains the active geometry.
+    assert list(data.columns) == ["id", "geometry"]
+    assert data.geometry.name == "geometry"
     assert data["id"].tolist() == [1, 2]
     assert list(data.geometry.geom_type) == ["Point", "Point"]
     assert pd.api.types.is_integer_dtype(data["id"])
@@ -174,10 +177,49 @@ def test_load_data_spatial_sqlite_detects_geometry(tmp_path):
 def test_load_data_spatial_sqlite_custom_geometry_column(tmp_path):
     import geopandas as gpd
 
+    # A non-default geometry column name is still detected and corrected to "geometry".
     resourcePath = _build_spatial_sqlite_resource(tmp_path, table="parcels", geom_column="shape")
     data, resource, schema = load_data(str(resourcePath), tableName="parcels")
     assert isinstance(data, gpd.GeoDataFrame)
+    assert "shape" not in data.columns
+    assert data.geometry.name == "geometry"
     assert list(data.geometry.geom_type) == ["Point", "Point"]
+
+
+def test_load_data_spatial_sqlite_restores_schema_case_and_selects_fields(tmp_path):
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    # Spatial SQLite with lowercase columns plus an extra non-schema column, paired with a camelCase schema.
+    dataPath = tmp_path / "data.sqlite"
+    con = sqlite3.connect(dataPath)
+    con.execute('CREATE TABLE "parcels" (personid INTEGER, fullname TEXT, extra TEXT, geom BLOB)')
+    con.executemany(
+        'INSERT INTO "parcels" (personid, fullname, extra, geom) VALUES (?, ?, ?, ?)',
+        [(1, "alice", "x", Point(0, 0).wkb), (2, "bob", "y", Point(1, 1).wkb)],
+    )
+    con.commit()
+    con.close()
+
+    (tmp_path / "data.schema.yaml").write_text(CAMEL_SCHEMA_YAML)
+    resourcePath = tmp_path / "data.resource.yaml"
+    resourcePath.write_text("\n".join([
+        "name: parcels",
+        "type: table",
+        "path: data.sqlite",
+        "format: sqlite",
+        "schema: data.schema.yaml",
+        "dialect:", "  sql:", "    table: parcels",
+    ]) + "\n")
+
+    data, resource, schema = load_data(str(resourcePath))
+    assert isinstance(data, gpd.GeoDataFrame)
+    # Schema fields restored to camelCase, extra column dropped, geometry retained as "geometry".
+    assert list(data.columns) == ["personId", "fullName", "geometry"]
+    assert "extra" not in data.columns
+    assert data["personId"].tolist() == [1, 2]
+    assert data.geometry.name == "geometry"
+    assert pd.api.types.is_integer_dtype(data["personId"])
 
 
 def test_load_data_spatial_sqlite_target_crs(tmp_path):


### PR DESCRIPTION
## Summary
The SQLite schema field-name correction in `load_data()` previously ran only for non-spatial tables (inside the tabular branch's SQL query). This moves it to run **after the data is loaded**, so it applies whether the SQLite database is spatial or not.

- Both paths now load all columns first — spatial via `load_spatial_data()`, tabular via `pd.read_sql_query('SELECT *')`.
- A single post-load correction step (gated by the schema) matches columns to schema fields case-insensitively, restores the schema casing, and selects only the schema fields.
- For spatial data, the detected geometry column is **retained and renamed to `"geometry"`** and re-activated via `set_geometry("geometry")`.

Non-spatial behavior is functionally unchanged (selection now happens in pandas after `SELECT *` rather than in SQL).

## Tests
- Strengthened the two spatial tests to assert the geometry column is renamed to `"geometry"` and stays active.
- Added `test_load_data_spatial_sqlite_restores_schema_case_and_selects_fields` (camelCase restoration + extra-column dropping on a spatial GeoDataFrame).
- `pytest tests/test_frictionless.py` → 11 passed.

## Release
Bumps `__version__` to `0.5.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)