### PR TITLE
Add shared street type and directional vocabulary

### DIFF
--- a/morpc/geocode.py
+++ b/morpc/geocode.py
@@ -1,6 +1,152 @@
 import logging
 logger = logging.getLogger(__name__)
 
+# Canonical USPS Publication 28 street type abbreviations, and the spelled-out forms and non-standard
+# variants observed in county auditor address data. Keys are upper case with no punctuation; look them
+# up through normalize_street_type() rather than directly, so that cleaning is applied consistently.
+#
+# This mapping is shared by the workflows that produce address data and the ones that match against it.
+# Keeping it in one place is the point: when the reference side and the query side normalize
+# differently, addresses that should join silently fail to.
+#
+# Values that are genuinely ambiguous are deliberately absent. "TR" is either TRL or TER and "BL" is
+# either BLVD or BLF, so mapping either one would be a guess. They pass through unchanged and are
+# reported as out of vocabulary instead.
+CONST_STREET_TYPE_ABBREV = {
+    "ALLEY": "ALY", "ALY": "ALY",
+    "AV": "AVE", "AVE": "AVE", "AVENUE": "AVE",
+    "BAYOU": "BYU", "BYU": "BYU",
+    "BEND": "BND", "BND": "BND",
+    "BLF": "BLF", "BLUFF": "BLF",
+    "BLVD": "BLVD", "BOULEVARD": "BLVD",
+    "CANYON": "CYN", "CYN": "CYN",
+    "CENTER": "CTR", "CTR": "CTR",
+    "CIR": "CIR", "CIRCLE": "CIR",
+    "CLB": "CLB", "CLUB": "CLB",
+    "CORNERS": "CORS", "CORS": "CORS",
+    "COURT": "CT", "CT": "CT",
+    "COVE": "CV", "CV": "CV",
+    "CREEK": "CRK", "CRK": "CRK",
+    "CRES": "CRES", "CRESCENT": "CRES",
+    "CROSSING": "XING", "XING": "XING",
+    "CURV": "CURV", "CURVE": "CURV",
+    "DR": "DR", "DRIVE": "DR",
+    "END": "END",
+    "EXPRESSWAY": "EXPY", "EXPY": "EXPY",
+    "EXT": "EXT", "EXTENSION": "EXT",
+    "FOREST": "FRST", "FRST": "FRST",
+    "GATEWAY": "GTWY", "GTWY": "GTWY",
+    "GLEN": "GLN", "GLN": "GLN",
+    "GREEN": "GRN", "GRN": "GRN",
+    "GROVE": "GRV", "GRV": "GRV",
+    "HEIGHTS": "HTS", "HTS": "HTS",
+    "HIGHWAY": "HWY", "HWY": "HWY",
+    "HILL": "HL", "HL": "HL",
+    "HOLLOW": "HOLW", "HOLW": "HOLW",
+    "ISLE": "ISLE",
+    "JCT": "JCT", "JUNCTION": "JCT",
+    "LANDING": "LNDG", "LNDG": "LNDG",
+    "LANE": "LN", "LN": "LN",
+    "LINK": "LINK",
+    "LOOP": "LOOP",
+    "MALL": "MALL",
+    "MANOR": "MNR", "MNR": "MNR",
+    "MEWS": "MEWS",
+    "OPAS": "OPAS",
+    "OVAL": "OVAL",
+    "PARK": "PARK", "PK": "PARK",
+    "PARKWAY": "PKWY", "PKWY": "PKWY", "PRKY": "PKWY",
+    "PASS": "PASS",
+    "PASSAGE": "PSGE", "PSGE": "PSGE",
+    "PATH": "PATH",
+    "PIKE": "PIKE",
+    "PL": "PL", "PLACE": "PL",
+    "PLAZA": "PLZ", "PLZ": "PLZ",
+    "POINT": "PT", "PT": "PT",
+    "RAMP": "RAMP",
+    "RD": "RD", "ROAD": "RD",
+    "RDS": "RDS", "ROADS": "RDS",
+    "RIDGE": "RDG", "RDG": "RDG",
+    "ROW": "ROW",
+    "RUN": "RUN",
+    "SPUR": "SPUR",
+    "SQ": "SQ", "SQUARE": "SQ",
+    "ST": "ST", "STREET": "ST",
+    "STREETS": "STS", "STS": "STS",
+    "TER": "TER", "TERRACE": "TER",
+    "TRACE": "TRCE", "TRAC": "TRCE", "TRCE": "TRCE",
+    "TRAIL": "TRL", "TRL": "TRL",
+    "UPAS": "UPAS",
+    "VIEW": "VW", "VW": "VW",
+    "VIS": "VIS", "VISTA": "VIS",
+    "WALK": "WALK",
+    "WAY": "WAY", "WY": "WAY",
+}
+
+# The canonical abbreviations, for validating that a normalized value is one MORPC recognizes.
+CONST_STREET_TYPES = frozenset(CONST_STREET_TYPE_ABBREV.values())
+
+# Directional prefixes and suffixes. Anything outside this mapping is not a direction, so
+# normalize_directional() discards it rather than passing it through.
+CONST_DIRECTIONAL_ABBREV = {
+    "N": "N", "NORTH": "N",
+    "S": "S", "SOUTH": "S",
+    "E": "E", "EAST": "E",
+    "W": "W", "WEST": "W",
+    "NE": "NE", "NORTHEAST": "NE",
+    "NW": "NW", "NORTHWEST": "NW",
+    "SE": "SE", "SOUTHEAST": "SE",
+    "SW": "SW", "SOUTHWEST": "SW",
+}
+
+# The canonical directionals.
+CONST_DIRECTIONALS = frozenset(CONST_DIRECTIONAL_ABBREV.values())
+
+
+def _clean(value):
+    """Upper case a value and strip surrounding whitespace and periods, or return None if it is empty.
+
+    Returns None for anything that is not a string, so that pandas nulls pass through untouched.
+    """
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().strip(".").strip().upper()
+    return cleaned if cleaned else None
+
+
+def normalize_street_type(value):
+    """Return the canonical USPS abbreviation for a street type.
+
+    Values already in canonical form are returned unchanged. Spelled-out forms ("ROAD") and the
+    non-standard variants seen in county data ("WY") are mapped to the abbreviation. A value with no
+    entry in CONST_STREET_TYPE_ABBREV is returned cleaned but otherwise unchanged, so that an
+    unrecognized type is preserved for review rather than destroyed; test membership of
+    CONST_STREET_TYPES to find those.
+
+    Returns None for null, non-string and empty input.
+    """
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    return CONST_STREET_TYPE_ABBREV.get(cleaned, cleaned)
+
+
+def normalize_directional(value):
+    """Return the canonical abbreviation for a directional prefix or suffix.
+
+    Unlike normalize_street_type(), a value that is not a direction is discarded rather than passed
+    through. A directional field can only hold one of eight values, so anything else is a parsing
+    error at the source rather than an unusual direction, and keeping it would only propagate the
+    error into joins.
+
+    Returns None for null, non-string, empty and non-directional input.
+    """
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    return CONST_DIRECTIONAL_ABBREV.get(cleaned)
+
+
 def geocode(addresses: list, endpoint=None):
     """
     Geocode a list of adresses.

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -1,0 +1,79 @@
+import morpc
+
+
+def test_canonical_street_types_pass_through():
+    for value in ["RD", "DR", "ST", "AVE", "CT", "LN", "BLVD", "XING", "TRCE"]:
+        assert morpc.normalize_street_type(value) == value
+
+
+def test_spelled_out_street_types_are_abbreviated():
+    assert morpc.normalize_street_type("ROAD") == "RD"
+    assert morpc.normalize_street_type("AVENUE") == "AVE"
+    assert morpc.normalize_street_type("STREET") == "ST"
+    assert morpc.normalize_street_type("COURT") == "CT"
+    assert morpc.normalize_street_type("PARKWAY") == "PKWY"
+    assert morpc.normalize_street_type("CROSSING") == "XING"
+
+
+def test_street_type_cleaning():
+    # Case, surrounding whitespace and trailing periods are all present in county auditor data.
+    assert morpc.normalize_street_type("Road") == "RD"
+    assert morpc.normalize_street_type("rd") == "RD"
+    assert morpc.normalize_street_type("DR ") == "DR"
+    assert morpc.normalize_street_type(" Ave. ") == "AVE"
+
+
+def test_non_standard_street_type_variants():
+    assert morpc.normalize_street_type("WY") == "WAY"
+    assert morpc.normalize_street_type("AV") == "AVE"
+    assert morpc.normalize_street_type("PRKY") == "PKWY"
+    assert morpc.normalize_street_type("TRAC") == "TRCE"
+
+
+def test_unrecognized_street_type_is_preserved_not_discarded():
+    # An unmapped value is cleaned but kept, so that it can be reported rather than silently lost.
+    assert morpc.normalize_street_type("THAYER") == "THAYER"
+    assert morpc.normalize_street_type("ST EXT") == "ST EXT"
+    assert "THAYER" not in morpc.CONST_STREET_TYPES
+
+
+def test_ambiguous_street_types_are_not_guessed():
+    # TR is either TRL or TER; BL is either BLVD or BLF. Neither is mapped.
+    assert morpc.normalize_street_type("TR") == "TR"
+    assert morpc.normalize_street_type("BL") == "BL"
+
+
+def test_street_type_null_handling():
+    assert morpc.normalize_street_type(None) is None
+    assert morpc.normalize_street_type("") is None
+    assert morpc.normalize_street_type("   ") is None
+    assert morpc.normalize_street_type(float("nan")) is None
+
+
+def test_directionals():
+    assert morpc.normalize_directional("N") == "N"
+    assert morpc.normalize_directional("NORTH") == "N"
+    assert morpc.normalize_directional("South") == "S"
+    assert morpc.normalize_directional("West") == "W"
+    assert morpc.normalize_directional("northwest") == "NW"
+
+
+def test_non_directional_values_are_discarded():
+    # These appear in the prefixdir field of the address point data and are parsing errors at the
+    # source, not unusual directions.
+    for value in ["DUNHAM", "A", "B", "C", "D", "<Null>"]:
+        assert morpc.normalize_directional(value) is None
+
+
+def test_directional_null_handling():
+    assert morpc.normalize_directional(None) is None
+    assert morpc.normalize_directional("") is None
+    assert morpc.normalize_directional(float("nan")) is None
+
+
+def test_canonical_sets_are_self_consistent():
+    # Every canonical value must itself normalize to itself, or repeated normalization would drift.
+    for value in morpc.CONST_STREET_TYPES:
+        assert morpc.normalize_street_type(value) == value
+    for value in morpc.CONST_DIRECTIONALS:
+        assert morpc.normalize_directional(value) == value


### PR DESCRIPTION
## Summary

Address data is produced by one set of MORPC workflows and matched against by another. When the two sides normalize differently, addresses that should join silently fail to — so the vocabulary belongs in one place rather than reimplemented per repository.

This adds that shared vocabulary to `morpc/geocode.py`:

- `CONST_STREET_TYPE_ABBREV` and `CONST_DIRECTIONAL_ABBREV` — the mappings
- `CONST_STREET_TYPES` and `CONST_DIRECTIONALS` — the canonical sets, for validating that a normalized value is one MORPC recognizes
- `normalize_street_type()` and `normalize_directional()` — the accessors, so cleaning is applied identically on both sides

No existing behavior changes. The Nominatim `geocode()` is untouched.

## Why the two functions treat unrecognized values differently

A street type is returned cleaned but otherwise unchanged. The vocabulary here is a subset of USPS Publication 28, so an unlisted type may still be legitimate and is preserved for review; test membership of `CONST_STREET_TYPES` to find those.

A directional is discarded. That field can only hold one of eight values, so anything else is a parsing error at the source rather than an unusual direction, and keeping it would propagate the error into joins.

Ambiguous abbreviations are deliberately unmapped: `TR` is either `TRL` or `TER`, and `BL` is either `BLVD` or `BLF`. Either mapping would be a guess, so both pass through and are reported as out of vocabulary instead.

## Measured against the reference

Against the 1,253,172 points in `morpc-addresspoints-standardize`, the vocabulary collapses 132 distinct street types to 68 canonical values and maps 1,167,743 of 1,188,782 populated records. Excluding Hocking, whose configuration error is fixed separately, 102 records across 23 values remain out of vocabulary (0.009%) — and every one is a genuine source defect: directionals in the type field, street names in the type field, and a handful of typos.

## Why this ships on its own

`geocode_local()` (#161) needs this, but so does the producer side. Releasing the vocabulary independently lets `morpc-addresspoints-standardize` start cleaning `prefixdir` and `streettype` against the same mapping the matcher will use, rather than waiting for the full match cascade to land.

## Testing

`tests/test_geocode.py` — 11 tests, all passing. Coverage includes canonical pass-through, spelled-out forms, case/whitespace/trailing-period cleaning, the non-standard variants observed in county data (`WY`, `PRKY`, `TRAC`), preservation of unrecognized types, the unmapped ambiguous pair, null handling, discarding of the non-directionals seen in `prefixdir` (`DUNHAM`, `A`, `B`, `C`, `D`), and a self-consistency check that every canonical value normalizes to itself so repeated normalization cannot drift.

The 4 failures in `tests/test_utils.py::test_datetime_*` on the full suite are pre-existing on `main` and unrelated — this branch touches only `geocode.py` and `test_geocode.py`.

Refs #161
Refs morpc/morpc-addresspoints-standardize#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
