### PR TITLE
Support GitHub release assets as resource data paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+
+.venv/
 *.pyc
 __pycache__/
 *.pkl

--- a/morpc/frictionless/__init__.py
+++ b/morpc/frictionless/__init__.py
@@ -1,1 +1,2 @@
 from .frictionless import *
+from .release import *

--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -409,9 +409,65 @@ def convert_lineend(path: str | PathLike, target: Literal['dos', 'unix']) -> Non
                 logger.error(f"Error changing line endings: {e}") 
                 raise RuntimeError
 
-def create_resource(dataPath, title=None, name=None, description=None, sources=None, resourcePath=None, schemaPath=None, resFormat=None, 
+def _is_url(path):
+    """Return True if a resource path is a URL rather than a local path."""
+    return str(path).startswith(("http://", "https://"))
+
+
+def _compute_hash(path, algorithm='md5'):
+    """Compute the hash of a file in the form that is emitted in a resource descriptor.
+
+    md5 is emitted as a bare hex digest, which is the Data Package v1 form and what MORPC resources have
+    always carried. sha256 is emitted in the self-describing v2 form "sha256:<hex>".
+    """
+    import morpc
+
+    if(algorithm == 'md5'):
+        return morpc.md5(path)
+    elif(algorithm == 'sha256'):
+        return "sha256:{}".format(morpc.sha256(path))
+    else:
+        logger.error("Unsupported hash algorithm: {}. Use 'md5' or 'sha256'.".format(algorithm))
+        raise RuntimeError
+
+
+def _verify_hash(path, expected):
+    """Raise if the file at path does not match the hash recorded in a resource descriptor.
+
+    Accepts both the bare hex digest that MORPC resources have historically carried, which is assumed to
+    be md5, and the self-describing "<algorithm>:<hex>" form.
+    """
+    import morpc
+
+    if(expected == None):
+        logger.warning("Resource carries no hash, so the integrity of {} cannot be verified.".format(path))
+        return
+
+    if(":" in expected):
+        (algorithm, _, digest) = expected.partition(":")
+        algorithm = algorithm.lower()
+    else:
+        (algorithm, digest) = ('md5', expected)
+
+    if(algorithm == 'md5'):
+        actual = morpc.md5(path)
+    elif(algorithm == 'sha256'):
+        actual = morpc.sha256(path)
+    else:
+        logger.error("Resource hash uses unsupported algorithm '{}'. Unable to verify {}.".format(algorithm, path))
+        raise RuntimeError
+
+    if(actual != digest):
+        logger.error("Hash mismatch for {}. The resource records {} but the file computes {}. The data does not match the resource that describes it.".format(path, digest, actual))
+        raise RuntimeError
+
+    logger.info("Verified {} against the {} hash recorded in the resource.".format(path, algorithm))
+
+
+def create_resource(dataPath, title=None, name=None, description=None, sources=None, resourcePath=None, schemaPath=None, resFormat=None,
                                  resProfile=None, resMediaType=None, computeHash=True, computeBytes=True, ignoreSchema=False, 
-                                 writeResource=False, validate=False, control=None, lineEnds: Literal['dos', 'unix'] = 'dos'):
+                                 writeResource=False, validate=False, control=None, lineEnds: Literal['dos', 'unix'] = 'dos',
+                                 cache=None, hashAlgorithm: Literal['md5', 'sha256'] = 'md5'):
     """Create a Frictionless resource object using sane default values for some attributes.  Optionally, write the 
     resource file to disk and validate the resource file, schema, and data. 
 
@@ -471,6 +527,15 @@ def create_resource(dataPath, title=None, name=None, description=None, sources=N
         Optional. For formats that are not standard tables, add a control from frictionless.formats
     lineEnds : ['\r\n', '\n']
         Convert all line endings in text files to DOS or UNIX stile endings. Defaults to '\r\n', DOS endings.
+    cache : str
+        Optional. The path to the local working copy of the data, RELATIVE TO THE LOCATION OF THE RESOURCE FILE.  Emitted in
+        the resource as the custom "_cache" property.  Specify this when dataPath is a URL, such as a GitHub release asset:
+        the authoritative copy lives at the URL, but the hash and size must be computed from the local file, and consumers
+        who already have the file on disk can read it without downloading.  See morpc.frictionless.publish_paths().
+    hashAlgorithm : ['md5', 'sha256']
+        Optional. The algorithm used to compute the hash attribute.  Defaults to 'md5', which is emitted as a bare hex digest
+        for backward compatibility (Data Package v1 style).  'sha256' is emitted in the self-describing Data Package v2 form
+        "sha256:<hex>".
 
     Returns
     -------
@@ -506,16 +571,24 @@ def create_resource(dataPath, title=None, name=None, description=None, sources=N
         ".sqlite": {
             "format": "sqlite",
             "mediatype": "application/vnd.sqlite3"
+        },
+        ".zip": {
+            "format": "zip",
+            "mediatype": "application/zip"
         }
     }
-    
-    dataFilePath = os.path.normpath(dataPath)
+
+    # A URL must not be passed through normpath, which would collapse the "//" in the scheme.
+    if _is_url(dataPath):
+        dataFilePath = dataPath
+    else:
+        dataFilePath = os.path.normpath(dataPath)
     dataFileName = os.path.splitext(os.path.basename(dataFilePath))[0]
     dataFileExtension = os.path.splitext(os.path.basename(dataFilePath))[1]
 
-    if(os.path.basename(dataFilePath) != os.path.normpath(dataFilePath)):
+    if(not _is_url(dataFilePath) and os.path.basename(dataFilePath) != os.path.normpath(dataFilePath)):
         # If dataFilePath is not simply a filename
-        logger.warning("You seem to have specified a data path that is not simply a file name.  This implies that the data is located in a different directory than the resource file.  Typically the data is located in the same directory as the resource file and the path is simply the filename.")   
+        logger.warning("You seem to have specified a data path that is not simply a file name.  This implies that the data is located in a different directory than the resource file.  Typically the data is located in the same directory as the resource file and the path is simply the filename.")
 
     resourceFilePath = None
     if(resourcePath != None):
@@ -524,7 +597,7 @@ def create_resource(dataPath, title=None, name=None, description=None, sources=N
             logger.warning("You specified a path for the resource file, however writeResource is not set to True. Resource file will not be written to disk.")   
 
         # If the user has specified a path to the resource file, we'll use it without modification. Warn the user if the choice is unusual.
-        if(os.path.basename(dataFilePath) != os.path.normpath(dataFilePath)):
+        if(not _is_url(dataFilePath) and os.path.basename(dataFilePath) != os.path.normpath(dataFilePath)):
             # If dataFilePath is not simply a filename
             if(os.path.dirname(os.path.abspath(resourcePath)) != os.path.dirname(os.path.abspath(dataFilePath))):
                 # If the absolute path to the resource file and the absolute path to the data put them in different directories
@@ -545,7 +618,7 @@ def create_resource(dataPath, title=None, name=None, description=None, sources=N
         # If ignoreSchema is False, determine the schema file path
         if(schemaPath != None):
             # If the user has specified a path to the resource file, we'll use it without modification. Warn the user if the choice is unusual.
-            if(os.path.basename(dataFilePath) != os.path.normpath(dataFilePath)):
+            if(not _is_url(dataFilePath) and os.path.basename(dataFilePath) != os.path.normpath(dataFilePath)):
                 # If dataFilePath is not simply a filename
                 if(os.path.dirname(os.path.abspath(schemaPath)) != os.path.dirname(os.path.abspath(dataFilePath))):
                     # If the absolute path to the schema file and the absolute path to the data put them in different directories
@@ -611,41 +684,47 @@ def create_resource(dataPath, title=None, name=None, description=None, sources=N
     if(not ignoreSchema):
         resource.schema = schemaFilePath
 
-    unlocatedDataWarningIssued = False
+    if(cache != None):
+        resource.custom["_cache"] = cache
 
-    if dataFileExtension == ".csv":
+    # The hash and size describe the bytes of the data.  When the path is a URL those bytes are not locally
+    # addressable, so resolve them from the cache, which is the local working copy of the same data.
+    if(cache != None):
+        localDataPath = cache
+    else:
+        localDataPath = dataFilePath
+
+    if(resourceFilePath != None):
+        localDataPath = os.path.join(os.path.dirname(resourceFilePath), localDataPath)
+    elif(computeHash or computeBytes):
+        logger.warning("Data path is specified relative to resource file, however no resource file path was specified. Assuming data path is relative to current working directory.")
+
+    if(dataFileExtension == ".csv" and not _is_url(dataFilePath)):
         if os.linesep == '\n':
             logger.info(f'Changing line endings.')
             if resourceFilePath == None:
                 logger.error(f"Unable to find resource as {resourceFilePath}")
                 raise RuntimeError
             else:
-                convert_lineend(os.path.join(os.path.dirname(resourceFilePath), dataFilePath), lineEnds)
+                convert_lineend(localDataPath, lineEnds)
+
+    if((computeHash or computeBytes) and _is_url(localDataPath)):
+        logger.error("Unable to compute hash or file size because the data path is a URL. Specify cache to point at the local working copy of the data.")
+        raise RuntimeError
 
     if(computeHash):
-        if(resourceFilePath != None):
-            resource.hash = morpc.md5(os.path.join(os.path.dirname(resourceFilePath), dataFilePath))
-        else:
-            try:
-                logger.warning("Data path is specified relative to resource file, however no resource file path was specified. Assuming data path is relative to current working directory.")
-                unlocatedDataWarningIssued = True
-                resource.hash = morpc.md5(dataFilePath)
-            except:
-                logger.error("Unable to compute MD5 hash.  Data file could not be located.")
-                raise RuntimeError            
+        try:
+            resource.hash = _compute_hash(localDataPath, hashAlgorithm)
+        except FileNotFoundError:
+            logger.error("Unable to compute hash.  Data file could not be located at {}.".format(localDataPath))
+            raise RuntimeError
 
     if(computeBytes):
-        # If the data path is relative, we need to know the resource file path
-        if(resourceFilePath != None):
-            resource.bytes = os.path.getsize(os.path.join(os.path.dirname(resourceFilePath), dataFilePath))
-        else:
-            try:
-                if(not unlocatedDataWarningIssued):
-                    logger.warning("Data path is specified relative to resource file, however no resource file path was specified. Assuming data path is relative to current working directory.")
-                resource.hash = morpc.md5(dataFilePath)
-            except:
-                logger.error("Unable to compute file size (bytes).  Data file could not be located.")
-                raise RuntimeError
+        try:
+            resource.bytes = os.path.getsize(localDataPath)
+        except FileNotFoundError:
+            logger.error("Unable to compute file size (bytes).  Data file could not be located at {}.".format(localDataPath))
+            raise RuntimeError
 
     if(writeResource):
         if(resourceFilePath != None):
@@ -745,6 +824,77 @@ def _detect_sqlite_geometry_column(con, tableName):
     return None
 
 
+def resolve_data_path(resource, sourceDir, download=True):
+    """Return the path to the local data file described by a resource, downloading it if necessary.
+
+    A resource may describe its data in two places. The path attribute is authoritative and may be a URL,
+    typically a GitHub release asset. The custom _cache attribute, when present, names the local working
+    copy relative to the resource file. This function resolves the two to a single local path:
+
+      1. If _cache is present and that file exists, use it.
+      2. Otherwise, if path is a URL and download is True, download it to the _cache location, or to a
+         temporary directory if no cache is specified.
+      3. Otherwise, join path to sourceDir, which is the behavior for an ordinary local resource.
+
+    In cases 1 and 2 the file is verified against the hash recorded in the resource. A mismatch raises
+    rather than warns, because a descriptor that disagrees with its own data cannot be reasoned about.
+
+    Parameters
+    ----------
+    resource : frictionless.Resource
+        The resource that describes the data.
+    sourceDir : str
+        The directory containing the resource file. Both path and _cache are interpreted relative to it.
+    download : bool
+        Optional. If False, a URL path raises rather than being downloaded. Defaults to True.
+
+    Returns
+    -------
+    str
+        The path to the local data file.
+    """
+    import os
+    import shutil
+    import tempfile
+    import morpc.req
+
+    cache = resource.custom.get("_cache") if resource.custom else None
+
+    if(cache != None):
+        cachePath = os.path.join(sourceDir, cache)
+        if(os.path.exists(cachePath)):
+            logger.info("Using local cached copy of the data at {}".format(cachePath))
+            _verify_hash(cachePath, resource.hash)
+            return cachePath
+        logger.info("Resource specifies a cache at {} but no file is present there.".format(cachePath))
+
+    if(_is_url(resource.path)):
+        if(not download):
+            logger.error("Data path is a URL and no local cache is available, but downloading is disabled.")
+            raise RuntimeError
+
+        if(cache != None):
+            targetPath = os.path.join(sourceDir, cache)
+        else:
+            logger.warning("Resource specifies a URL but no _cache, so the download cannot be reused. Downloading to a temporary directory.")
+            targetPath = os.path.join(tempfile.mkdtemp(), os.path.basename(resource.path))
+
+        targetDir = os.path.dirname(os.path.abspath(targetPath))
+        os.makedirs(targetDir, exist_ok=True)
+
+        logger.info("Downloading data from {} to {}".format(resource.path, targetPath))
+        downloadedPath = morpc.req.get_file_safely(resource.path, targetDir, returnPath=True)
+
+        # get_file_safely names the downloaded file after the URL. If the cache calls it something else, move it.
+        if(os.path.abspath(downloadedPath) != os.path.abspath(targetPath)):
+            shutil.move(downloadedPath, targetPath)
+
+        _verify_hash(targetPath, resource.hash)
+        return targetPath
+
+    return os.path.join(sourceDir, resource.path)
+
+
 def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False, forceInt64=False, useSchema="default", sheetName=None, layerName=None, tableName=None, driverName=None, targetCRS=None, lineEnds: Literal['\n', '\b\n'] = '\b\n'):
     """Often we want to make a copy of some input data and work with the copy, for example to protect 
     the original data or to create an archival copy of it so that we can replicate the process later.  
@@ -817,7 +967,12 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
     
     sourceDir = os.path.dirname(myResourcePath)
     resourceFilename = os.path.basename(myResourcePath)
-    dataFileExtension = os.path.splitext(resource.path)[1]
+
+    # Resolve the resource's path and _cache to a single local file, downloading it if the path is a
+    # release asset URL and no local copy is present. The extension must come from the resolved local
+    # file rather than from resource.path, which may be a URL.
+    sourceDataPath = resolve_data_path(resource, sourceDir)
+    dataFileExtension = os.path.splitext(sourceDataPath)[1]
     
     # Surely there is a more convenient way to get the schema path from the Resource object?
     if(useSchema == None):
@@ -843,7 +998,7 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
     if(archiveDir != None):
 
         targetResource = os.path.join(archiveDir, resourceFilename)
-        targetData = os.path.join(archiveDir, resource.path)
+        targetData = os.path.join(archiveDir, os.path.basename(sourceDataPath))
         if(schemaFilename != None):
             targetSchema = os.path.join(archiveDir, schemaFilename)
         else:
@@ -853,7 +1008,7 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
             logger.info("Copying data, resource file, and schema (if applicable) to directory {}".format(archiveDir))    
 
             shutil.copyfile(os.path.join(sourceDir, resourceFilename), targetResource)
-            shutil.copyfile(os.path.join(sourceDir, resource.path), targetData)
+            shutil.copyfile(sourceDataPath, targetData)
             if(targetSchema != None):
                 shutil.copyfile(schemaSourcePath, targetSchema)
         except Exception as e:
@@ -862,7 +1017,7 @@ def load_data(resourcePath, archiveDir=None, validate=False, forceInteger=False,
     
     else:           
         targetResource = os.path.join(sourceDir, resourceFilename)
-        targetData = os.path.join(sourceDir, resource.path)
+        targetData = sourceDataPath
         if(schemaFilename != None):
             targetSchema = schemaSourcePath
         else:

--- a/morpc/frictionless/release.py
+++ b/morpc/frictionless/release.py
@@ -123,4 +123,9 @@ def publish_paths(resource, owner, repo, tag):
     descriptor["path"] = release_asset_url(owner, repo, tag, filename)
     descriptor["_cache"] = localPath
 
+    # The scheme describes the path, which has just changed from a local file to a URL. Frictionless
+    # preserves an explicit scheme rather than re-deriving it, so a stale "file" would survive onto a
+    # descriptor whose path is https. Drop it and let frictionless infer the scheme from the new path.
+    descriptor.pop("scheme", None)
+
     return frictionless.Resource.from_descriptor(descriptor)

--- a/morpc/frictionless/release.py
+++ b/morpc/frictionless/release.py
@@ -1,0 +1,126 @@
+"""Helpers for describing MORPC data outputs that are published as GitHub release assets.
+
+Large build outputs are too big for Git LFS to hold economically, but they fit comfortably in a
+GitHub release asset, which counts against neither the LFS quota nor the repository size. A release
+asset URL is fully determined by (owner, repo, tag, filename), so a resource descriptor can be
+written before the release exists, provided the tag is chosen first.
+"""
+
+import logging
+logger = logging.getLogger(__name__)
+
+RELEASE_ASSET_URL_TEMPLATE = "https://github.com/{owner}/{repo}/releases/download/{tag}/{filename}"
+
+
+def release_asset_url(owner, repo, tag, filename):
+    """Return the download URL for a GitHub release asset.
+
+    This is the single place the release asset URL shape is encoded. Callers should use it rather
+    than composing the URL themselves, so that a change to the shape is made in one place.
+
+    Parameters
+    ----------
+    owner : str
+        The GitHub organization or user that owns the repository, e.g. "morpc".
+    repo : str
+        The repository name, e.g. "morpc-parcels-standardize".
+    tag : str
+        The release tag, e.g. "v2026.7.22". Note the leading "v", which is part of the tag but not
+        part of the package version.
+    filename : str
+        The name of the asset as published in the release.
+
+    Returns
+    -------
+    str
+        The asset download URL.
+    """
+    return RELEASE_ASSET_URL_TEMPLATE.format(owner=owner, repo=repo, tag=tag, filename=filename)
+
+
+def calver(date=None, sequence=None):
+    """Return an unpadded CalVer version string, e.g. "2026.7.22".
+
+    The version is unpadded deliberately. create_package() coerces the version through
+    packaging.Version, which silently normalizes a zero-padded "2026.07.22" to "2026.7.22". That
+    would break the correspondence between the package version and the release tag that the asset
+    URL depends on. Unpadded values round-trip unchanged, and this function asserts that they do.
+
+    Parameters
+    ----------
+    date : datetime.date
+        Optional. The date to derive the version from. Defaults to today.
+    sequence : int
+        Optional. A same-day rebuild counter, appended as a fourth component, e.g. "2026.7.22.1".
+        If unspecified, the version has three components.
+
+    Returns
+    -------
+    str
+        The version string, which is guaranteed to round-trip through packaging.Version.
+    """
+    import datetime
+    from packaging.version import Version
+
+    if date is None:
+        date = datetime.date.today()
+
+    version = "{}.{}.{}".format(date.year, date.month, date.day)
+    if sequence is not None:
+        version = "{}.{}".format(version, sequence)
+
+    if str(Version(version)) != version:
+        logger.error("Version {} does not round-trip through packaging.Version.".format(version))
+        raise RuntimeError
+
+    return version
+
+
+def publish_paths(resource, owner, repo, tag):
+    """Return a copy of a resource whose path points at a release asset and whose _cache points at the local file.
+
+    This is what a CI workflow runs at release time. The resource as built locally has a local file
+    name in its path. Publishing rewrites that path to the immutable release asset URL and records
+    the local file name in _cache, so that the same descriptor serves both consumers who must
+    download the data and local development where the file is already on disk.
+
+    The hash and bytes of the original resource are preserved, so a consumer that downloads the
+    asset can verify it against the descriptor.
+
+    Parameters
+    ----------
+    resource : frictionless.Resource
+        The resource as built locally, whose path is a local file name.
+    owner : str
+        The GitHub organization or user that owns the repository.
+    repo : str
+        The repository name.
+    tag : str
+        The release tag the asset is published under, e.g. "v2026.7.22".
+
+    Returns
+    -------
+    frictionless.Resource
+        A new resource. The original is not modified.
+    """
+    import os
+    import frictionless
+    from .frictionless import _is_url
+
+    descriptor = resource.to_dict()
+    localPath = descriptor.get("path")
+
+    if localPath is None:
+        logger.error("Resource has no path. Unable to determine the asset filename.")
+        raise RuntimeError
+
+    if _is_url(localPath):
+        logger.warning("Resource path is already a URL. It will be replaced with the release asset URL for tag {}.".format(tag))
+        localPath = descriptor.get("_cache", os.path.basename(localPath))
+
+    filename = os.path.basename(localPath)
+
+    descriptor["path"] = release_asset_url(owner, repo, tag, filename)
+    descriptor["_cache"] = localPath
+
+    return frictionless.Resource.from_descriptor(descriptor)

--- a/morpc/morpc.py
+++ b/morpc/morpc.py
@@ -2989,6 +2989,23 @@ def md5(fname):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
+def sha256(fname):
+    """
+    sha256() computes the SHA-256 checksum for a file.  When the original checksum is known, the current checksum can be compared to it to determine whether the file has changed.
+
+    Input parameters:
+      - fname is a string representing the path to the file for which the checksum is to be computed
+
+     Returns:
+       - SHA-256 checksum for the file
+    """
+    import hashlib
+    hash_sha256 = hashlib.sha256()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_sha256.update(chunk)
+    return hash_sha256.hexdigest()
+
 def write_table(df, path, format=None, index=None):
     """Write a pandas dataframe to a tabular data file applying MORPC file standards
     

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,411 @@
+"""Tests for release-asset resource descriptors: the _cache property, hash resolution, and calver."""
+
+import datetime
+import os
+import shutil
+
+import frictionless
+import pytest
+
+from morpc.frictionless import (
+    calver,
+    create_resource,
+    publish_paths,
+    release_asset_url,
+    resolve_data_path,
+)
+
+
+ASSET_URL = "https://github.com/morpc/morpc-parcels-standardize/releases/download/v2026.7.22/data.csv"
+
+SCHEMA_YAML = """\
+fields:
+  - name: id
+    type: integer
+  - name: name
+    type: string
+"""
+
+
+def _build_data(dirpath, name="data.csv"):
+    """Write a small CSV plus its schema sidecar into dirpath. Returns the data file path."""
+    dataPath = dirpath / name
+    dataPath.write_bytes(b"id,name\r\n1,alice\r\n2,bob\r\n")
+    (dirpath / name.replace(".csv", ".schema.yaml")).write_text(SCHEMA_YAML)
+    return dataPath
+
+
+# --- release_asset_url ---
+
+def test_release_asset_url_shape():
+    url = release_asset_url("morpc", "morpc-parcels-standardize", "v2026.7.22", "data.csv")
+    assert url == ASSET_URL
+
+
+# --- calver ---
+
+def test_calver_is_unpadded_and_round_trips():
+    from packaging.version import Version
+
+    version = calver(datetime.date(2026, 7, 22))
+    assert version == "2026.7.22"
+    # A zero-padded version would normalize to something else, breaking the tag correspondence.
+    assert str(Version(version)) == version
+
+
+def test_calver_with_sequence():
+    version = calver(datetime.date(2026, 7, 22), sequence=1)
+    assert version == "2026.7.22.1"
+
+
+def test_calver_defaults_to_today():
+    today = datetime.date.today()
+    assert calver() == "{}.{}.{}".format(today.year, today.month, today.day)
+
+
+# --- create_resource: hash algorithm ---
+
+def test_create_resource_default_hash_is_bare_md5(tmp_path):
+    # The historical Data Package v1 form. Existing callers must be unaffected by the new defaults.
+    _build_data(tmp_path)
+    resource = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+    )
+    assert ":" not in resource.hash
+    assert len(resource.hash) == 32
+    assert resource.bytes == os.path.getsize(tmp_path / "data.csv")
+
+
+def test_create_resource_sha256_is_self_describing(tmp_path):
+    import morpc
+
+    dataPath = _build_data(tmp_path)
+    resource = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        hashAlgorithm="sha256",
+    )
+    assert resource.hash == "sha256:{}".format(morpc.sha256(str(dataPath)))
+
+
+def test_create_resource_unsupported_hash_algorithm_raises(tmp_path):
+    _build_data(tmp_path)
+    with pytest.raises(RuntimeError):
+        create_resource(
+            "data.csv",
+            resourcePath=str(tmp_path / "data.resource.yaml"),
+            ignoreSchema=True,
+            hashAlgorithm="crc32",
+        )
+
+
+# --- create_resource: cache ---
+
+def test_create_resource_hash_and_bytes_come_from_cache_when_path_is_url(tmp_path):
+    dataPath = _build_data(tmp_path)
+    local = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        hashAlgorithm="sha256",
+    )
+    remote = create_resource(
+        ASSET_URL,
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        cache="data.csv",
+        name="parcels",
+        hashAlgorithm="sha256",
+    )
+    # The URL is not locally addressable, so the bytes are resolved through the cache. They describe
+    # the same file, so the hash and size must agree with the purely local resource.
+    assert remote.path == ASSET_URL
+    assert remote.custom["_cache"] == "data.csv"
+    assert remote.hash == local.hash
+    assert remote.bytes == local.bytes == os.path.getsize(dataPath)
+
+
+def test_create_resource_url_without_cache_raises(tmp_path):
+    _build_data(tmp_path)
+    with pytest.raises(RuntimeError):
+        create_resource(
+            ASSET_URL,
+            resourcePath=str(tmp_path / "data.resource.yaml"),
+            ignoreSchema=True,
+            name="parcels",
+        )
+
+
+def test_create_resource_url_without_cache_is_fine_when_nothing_is_computed(tmp_path):
+    # With no hash or size to compute there is nothing that needs local bytes.
+    resource = create_resource(
+        ASSET_URL,
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        name="parcels",
+        computeHash=False,
+        computeBytes=False,
+    )
+    assert resource.path == ASSET_URL
+    assert resource.format == "csv"
+
+
+def test_create_resource_cache_round_trips_through_disk(tmp_path):
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        ASSET_URL,
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        cache="data.csv",
+        name="parcels",
+        writeResource=True,
+    )
+    # _cache is a custom property, so the round trip is the thing worth asserting: frictionless must
+    # preserve it through write and read rather than dropping it as unrecognized.
+    reread = frictionless.Resource(str(resourcePath))
+    assert reread.path == ASSET_URL
+    assert reread.custom["_cache"] == "data.csv"
+
+
+# --- resolve_data_path ---
+
+def test_resolve_data_path_plain_local_resource(tmp_path):
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        "data.csv",
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        writeResource=True,
+    )
+    resource = frictionless.Resource(str(resourcePath))
+    resolved = resolve_data_path(resource, str(tmp_path))
+    assert os.path.abspath(resolved) == os.path.abspath(tmp_path / "data.csv")
+
+
+def test_resolve_data_path_cache_hit_does_not_download(tmp_path, monkeypatch):
+    import morpc.req
+
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        ASSET_URL,
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        cache="data.csv",
+        name="parcels",
+        writeResource=True,
+    )
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("The cached copy is present, so no download should be attempted.")
+
+    monkeypatch.setattr(morpc.req, "get_file_safely", _fail)
+
+    resource = frictionless.Resource(str(resourcePath))
+    resolved = resolve_data_path(resource, str(tmp_path))
+    assert os.path.abspath(resolved) == os.path.abspath(tmp_path / "data.csv")
+
+
+def test_resolve_data_path_cache_miss_downloads_to_cache(tmp_path, monkeypatch):
+    import morpc.req
+
+    sourceDir = tmp_path / "source"
+    sourceDir.mkdir()
+    _build_data(sourceDir)
+    resourcePath = sourceDir / "data.resource.yaml"
+    create_resource(
+        ASSET_URL,
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        cache="data.csv",
+        name="parcels",
+        writeResource=True,
+    )
+
+    # Stand the data up somewhere else and remove the cached copy, so the resource describes data
+    # that is not present locally.
+    origin = tmp_path / "origin" / "data.csv"
+    origin.parent.mkdir()
+    shutil.move(str(sourceDir / "data.csv"), str(origin))
+
+    def _fake_download(url, output_dir, returnPath=False, **kwargs):
+        assert url == ASSET_URL
+        target = os.path.join(output_dir, os.path.basename(url))
+        shutil.copyfile(str(origin), target)
+        return target
+
+    monkeypatch.setattr(morpc.req, "get_file_safely", _fake_download)
+
+    resource = frictionless.Resource(str(resourcePath))
+    resolved = resolve_data_path(resource, str(sourceDir))
+    # The download lands at the cache location, so a second call is served locally.
+    assert os.path.abspath(resolved) == os.path.abspath(sourceDir / "data.csv")
+    assert os.path.exists(sourceDir / "data.csv")
+
+
+def test_resolve_data_path_url_without_cache_uses_temporary_directory(tmp_path, monkeypatch):
+    import morpc.req
+
+    origin = tmp_path / "origin" / "data.csv"
+    origin.parent.mkdir()
+    _build_data(origin.parent)
+
+    resource = frictionless.Resource.from_descriptor({
+        "name": "parcels",
+        "path": ASSET_URL,
+        "format": "csv",
+    })
+
+    def _fake_download(url, output_dir, returnPath=False, **kwargs):
+        target = os.path.join(output_dir, os.path.basename(url))
+        shutil.copyfile(str(origin), target)
+        return target
+
+    monkeypatch.setattr(morpc.req, "get_file_safely", _fake_download)
+
+    resolved = resolve_data_path(resource, str(tmp_path))
+    assert os.path.exists(resolved)
+    # Nothing was written into the resource directory, since the resource named no cache.
+    assert not os.path.exists(tmp_path / "data.csv")
+
+
+def test_resolve_data_path_download_disabled_raises(tmp_path):
+    resource = frictionless.Resource.from_descriptor({
+        "name": "parcels",
+        "path": ASSET_URL,
+        "format": "csv",
+    })
+    with pytest.raises(RuntimeError):
+        resolve_data_path(resource, str(tmp_path), download=False)
+
+
+def test_resolve_data_path_hash_mismatch_raises(tmp_path):
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        ASSET_URL,
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        cache="data.csv",
+        name="parcels",
+        writeResource=True,
+    )
+
+    # The cached file no longer matches the hash the resource records for it.
+    (tmp_path / "data.csv").write_bytes(b"id,name\r\n1,changed\r\n")
+
+    resource = frictionless.Resource(str(resourcePath))
+    with pytest.raises(RuntimeError):
+        resolve_data_path(resource, str(tmp_path))
+
+
+def test_resolve_data_path_verifies_sha256_hash(tmp_path):
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        ASSET_URL,
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        cache="data.csv",
+        name="parcels",
+        hashAlgorithm="sha256",
+        writeResource=True,
+    )
+    resource = frictionless.Resource(str(resourcePath))
+    assert resource.hash.startswith("sha256:")
+    # Verification passes on the intact file and fails once the bytes change.
+    resolve_data_path(resource, str(tmp_path))
+    (tmp_path / "data.csv").write_bytes(b"id,name\r\n1,changed\r\n")
+    with pytest.raises(RuntimeError):
+        resolve_data_path(resource, str(tmp_path))
+
+
+# --- publish_paths ---
+
+def test_publish_paths_rewrites_path_and_records_cache(tmp_path):
+    _build_data(tmp_path)
+    local = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        name="parcels",
+    )
+    published = publish_paths(local, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+
+    assert published.path == ASSET_URL
+    assert published.custom["_cache"] == "data.csv"
+    # The hash and bytes carry over, so a consumer can verify the downloaded asset.
+    assert published.hash == local.hash
+    assert published.bytes == local.bytes
+    # The original resource is not modified.
+    assert local.path == "data.csv"
+    assert "_cache" not in local.custom
+
+
+def test_publish_paths_on_an_already_published_resource_retags(tmp_path):
+    _build_data(tmp_path)
+    local = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        name="parcels",
+    )
+    once = publish_paths(local, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+    twice = publish_paths(once, "morpc", "morpc-parcels-standardize", "v2026.8.1")
+
+    assert twice.path.endswith("/download/v2026.8.1/data.csv")
+    assert twice.custom["_cache"] == "data.csv"
+
+
+def test_publish_paths_without_a_path_raises():
+    resource = frictionless.Resource.from_descriptor({"name": "parcels", "data": [["id"], [1]]})
+    with pytest.raises(RuntimeError):
+        publish_paths(resource, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+
+
+# --- load_data ---
+
+def test_load_data_reads_through_the_cache(tmp_path, monkeypatch):
+    import morpc.req
+    from morpc.frictionless import load_data
+
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        ASSET_URL,
+        resourcePath=str(resourcePath),
+        schemaPath="data.schema.yaml",
+        cache="data.csv",
+        name="parcels",
+        writeResource=True,
+    )
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("The cached copy is present, so no download should be attempted.")
+
+    monkeypatch.setattr(morpc.req, "get_file_safely", _fail)
+
+    data, resource, schema = load_data(str(resourcePath))
+    assert list(data.columns) == ["id", "name"]
+    assert data["name"].tolist() == ["alice", "bob"]
+
+
+def test_load_data_local_resource_is_unaffected(tmp_path):
+    from morpc.frictionless import load_data
+
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        "data.csv",
+        resourcePath=str(resourcePath),
+        schemaPath="data.schema.yaml",
+        name="parcels",
+        writeResource=True,
+    )
+    data, resource, schema = load_data(str(resourcePath))
+    assert data["id"].tolist() == [1, 2]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -347,6 +347,43 @@ def test_publish_paths_rewrites_path_and_records_cache(tmp_path):
     assert "_cache" not in local.custom
 
 
+def test_publish_paths_updates_the_scheme(tmp_path):
+    _build_data(tmp_path)
+    local = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        name="parcels",
+    )
+    assert local.scheme == "file"
+    published = publish_paths(local, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+    # Frictionless preserves an explicit scheme rather than re-deriving it, so a stale "file" would
+    # otherwise survive onto a descriptor whose path is a URL.
+    assert published.scheme == "https"
+
+
+def test_publish_paths_preserves_dialect_and_schema(tmp_path, monkeypatch):
+    # A sqlite resource carries a dialect naming the table and a schema sidecar reference. Both must
+    # survive the rewrite, or the published descriptor cannot open the data it points at.
+    from frictionless import formats
+
+    # A resource built in memory has no basepath, so its schema reference resolves against the working
+    # directory.
+    monkeypatch.chdir(tmp_path)
+    _build_data(tmp_path)
+    local = create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        schemaPath="data.schema.yaml",
+        name="parcels",
+        control=formats.SqlControl(table="addresspoints"),
+    )
+    published = publish_paths(local, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+    descriptor = published.to_dict()
+    assert descriptor["dialect"] == {"sql": {"table": "addresspoints"}}
+    assert descriptor["schema"] == "data.schema.yaml"
+
+
 def test_publish_paths_on_an_already_published_resource_retags(tmp_path):
     _build_data(tmp_path)
     local = create_resource(


### PR DESCRIPTION
Closes #159.

Large build outputs are too big for Git LFS to hold economically, but they fit comfortably in a GitHub release asset, which counts against neither the LFS quota nor the repository size. To describe data published that way, a resource needs a `path` that is a URL — and a local file to compute its hash and size from. This adds both halves.

## `create_resource()`

Two new parameters, both defaulting to current behavior:

| Parameter | Meaning |
| --- | --- |
| `cache` | The local working copy of the data, relative to the resource file. Emitted as the custom `_cache` property. When `path` is a URL the bytes are not locally addressable, so hash and size are resolved through the cache instead. |
| `hashAlgorithm` | `'md5'` (default, bare hex digest — unchanged) or `'sha256'` (self-describing `sha256:<hex>`). |

The bare-MD5 default is deliberate: it is the Data Package v1 form every existing MORPC resource carries, so nothing already on disk is invalidated. `sha256` is opt-in.

A URL path is now kept clear of `os.path.normpath`, which would collapse the `//` in the scheme, and of the CSV line-ending conversion, which needs a local file. Asking for a hash or size from a URL with no `cache` raises with an explanation rather than failing obscurely.

## `resolve_data_path()`

Resolves `path` and `_cache` to a single local file:

1. `_cache` present and the file exists → use it.
2. Otherwise `path` is a URL → download it to the cache location, or to a temp directory if no cache is named.
3. Otherwise → join `path` to the resource directory, which is the ordinary local behavior.

In cases 1 and 2 the file is verified against the recorded hash. **A mismatch raises rather than warns** — a descriptor that disagrees with its own data cannot be reasoned about. `load_data()` now goes through this, so a local resource behaves exactly as before while a release-asset resource is downloaded on first read and served from the cache afterward.

## `morpc/frictionless/release.py`

- `release_asset_url()` — the single place the asset URL shape is encoded.
- `publish_paths()` — what a release workflow runs. Rewrites a locally built resource's path to the immutable asset URL and records the local filename in `_cache`, so one descriptor serves both consumers who must download and local development where the file is already present. Returns a copy; the original is untouched.
- `calver()` — builds an unpadded CalVer version. The padding matters: `create_package()` coerces the version through `packaging.Version`, which silently normalizes `2026.07.22` → `2026.7.22`. That would break the correspondence between the package version and the release tag the asset URL depends on. The function asserts the version round-trips.

## Also in here

- `morpc.sha256()`, mirroring the existing `md5()`.
- `.zip` added to the extension map.
- **A pre-existing bug fix.** The `computeBytes` fallback branch assigned `resource.hash = morpc.md5(...)` where it meant `resource.bytes = os.path.getsize(...)`, so a resource built without a `resourcePath` silently got no `bytes`. It sits inside the block this work had to rewrite, so leaving it would have meant carrying it forward deliberately.

## Testing

`tests/test_release.py`, 23 tests, covering everything #159 asks for: `_cache` round-tripping through write → read, hash and bytes resolved from the cache when the path is a URL, `resolve_data_path` precedence across all three branches, hash mismatch raising, `calver()` round-tripping through `packaging.Version`, and existing `create_resource` / `load_data` callers being unaffected by the new defaults. Downloads are exercised through a monkeypatched `get_file_safely`, so the suite stays offline.

Full suite: **85 passed, 4 failed**. The 4 are the pre-existing `test_utils` datetime failures, failing identically on `main`. No regression.

## Note for review

Two whitespace-only lines appear in the `frictionless.py` diff — trailing spaces stripped from lines adjacent to real edits. Incidental, not intentional cleanup.

## What this unblocks

morpc/morpc-py#161 (local geocoder) is paused pending this. The motivating case: `morpc-addresspoints-standardize` currently declares `version: 2026.7.22` in `package.yaml` for a build `created: 2026-07-29`, so the declared version does not distinguish one build from another. `_cache` plus a verified hash plus a tag-aligned CalVer gives consumers a way to pin a specific build of that dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
