### PR TITLE
Add prepare_release and create_release for multi-resource releases

### DIFF
--- a/morpc/__init__.py
+++ b/morpc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.14"
+__version__ = "0.5.15"
 
 import logging
 logger = logging.getLogger(__name__)

--- a/morpc/frictionless/release.py
+++ b/morpc/frictionless/release.py
@@ -129,3 +129,223 @@ def publish_paths(resource, owner, repo, tag):
     descriptor.pop("scheme", None)
 
     return frictionless.Resource.from_descriptor(descriptor)
+
+
+def prepare_release(resources, owner, repo, tag, version=None, packageName=None, dir=None):
+    """Rewrite a set of resource descriptors to point at a release's asset URLs, and rewrite them to disk.
+
+    This is the multi-resource counterpart to publish_paths(): it loads each descriptor, publishes its
+    path and _cache for the given tag, and writes the result back over the original file. Optionally it
+    also bundles the resources into a data package, which is how a workflow that produces several
+    related outputs (e.g. a database, a resource, a schema) hands them off together.
+
+    Parameters
+    ----------
+    resources : str or list of str
+        Path(s) to resource descriptor files. A single path may be passed as a bare string.
+    owner : str
+        The GitHub organization or user that owns the repository.
+    repo : str
+        The repository name.
+    tag : str
+        The release tag the assets will be published under, e.g. "v2026.7.22".
+    version : str
+        Optional. The version to record in the data package, used only when packageName is given.
+        Defaults to tag with a single leading "v" stripped.
+    packageName : str
+        Optional. If given, bundle the published resources into a data package named packageName,
+        written as "{packageName}.package.yaml" in dir. If omitted, no package is created.
+    dir : str
+        Optional. The directory the resource descriptors live in, used only when packageName is given,
+        since create_package() requires resource paths relative to a single directory. Defaults to the
+        common directory of the descriptor paths in resources.
+
+    Returns
+    -------
+    list of frictionless.Resource
+        The published resources, in the same order as resources.
+    """
+    import os
+    import frictionless
+    from .frictionless import create_package, write_resource
+
+    if isinstance(resources, str):
+        resources = [resources]
+
+    published = []
+    for resourcePath in resources:
+        resource = frictionless.Resource(resourcePath)
+        publishedResource = publish_paths(resource, owner, repo, tag)
+        write_resource(publishedResource, resourcePath)
+        published.append(publishedResource)
+
+    if packageName is not None:
+        if dir is None:
+            # Compared as absolute paths so that equivalent spellings of one directory ("output_data"
+            # and "./output_data") are not mistaken for two.
+            dirs = {os.path.abspath(os.path.dirname(resourcePath)) for resourcePath in resources}
+            if len(dirs) > 1:
+                logger.error("Resource descriptors are not all in the same directory. create_package() requires resource paths relative to a single directory; pass dir explicitly.")
+                raise RuntimeError
+
+            # A bare filename has no dirname, but create_package() needs a real directory to resolve
+            # the resource paths against.
+            dir = os.path.dirname(resources[0]) or "."
+
+        if version is None:
+            version = tag[1:] if tag.startswith("v") else tag
+
+        resourceNames = [os.path.basename(resourcePath) for resourcePath in resources]
+        create_package(dir, resourceNames, packageName, version)
+
+    return published
+
+
+def _format_bytes(size):
+    """Return a human-readable byte count using binary units, e.g. "175.1 MB"."""
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            if unit == "B":
+                return "{:.0f} B".format(value)
+            return "{:.1f} {}".format(value, unit)
+        value /= 1024
+
+
+def create_release(resources, owner, repo, tag, title=None, notes=None, assets=None, dryRun=False):
+    """Create a GitHub release from a set of published resource descriptors.
+
+    This is the multi-resource counterpart to the hand-rolled `gh release create` step a workflow
+    would otherwise run itself. It derives the asset list from the resources rather than requiring the
+    caller to re-enumerate files, and it writes release notes summarizing each resource.
+
+    Only descriptor paths are accepted, not in-memory frictionless.Resource objects: a Resource built
+    in memory may have no known descriptor path, and the descriptor file is itself an asset that must
+    be uploaded. Use prepare_release() to publish descriptors first; pass the same paths here.
+
+    Parameters
+    ----------
+    resources : str or list of str
+        Path(s) to resource descriptor files. A single path may be passed as a bare string.
+    owner : str
+        The GitHub organization or user that owns the repository.
+    repo : str
+        The repository name.
+    tag : str
+        The release tag, e.g. "v2026.7.22". Raises if a release with this tag already exists, since a
+        tag may only be cut once: moving one would leave published descriptors pointing at bytes that
+        changed underneath them.
+    title : str
+        Optional. The release title. Defaults to tag.
+    notes : str
+        Optional. Introductory text placed above the generated "## Resources" section of the release
+        notes.
+    assets : list of str
+        Optional. Extra asset paths to upload alongside the ones derived from resources, e.g. a data
+        package descriptor.
+    dryRun : bool
+        Optional. If True, run every preflight check except the tag-existence check, log the resolved
+        asset list and notes, and return without creating a release or calling `gh` to check the tag.
+        Defaults to False.
+
+    Returns
+    -------
+    (list of str, str)
+        The de-duplicated list of asset paths, and the rendered release notes. Returned in both the
+        real and dry-run cases so callers and tests can inspect what was or would be sent.
+    """
+    import os
+    import shutil
+    import subprocess
+    import frictionless
+    from .frictionless import _is_url
+
+    if isinstance(resources, str):
+        resources = [resources]
+
+    descriptors = []
+    assetPaths = []
+    for resourcePath in resources:
+        resourceDir = os.path.dirname(resourcePath)
+        descriptor = frictionless.Resource(resourcePath).to_dict()
+        descriptors.append(descriptor)
+
+        cache = descriptor.get("_cache")
+        path = descriptor.get("path")
+        if cache is not None:
+            dataPath = os.path.join(resourceDir, cache)
+        elif path is not None and not _is_url(path):
+            dataPath = os.path.join(resourceDir, path)
+        else:
+            logger.error("Resource {} has no local data to upload: path is a URL and no _cache is recorded.".format(resourcePath))
+            raise RuntimeError
+        assetPaths.append(dataPath)
+        assetPaths.append(resourcePath)
+
+        schema = descriptor.get("schema")
+        if isinstance(schema, str) and not _is_url(schema):
+            assetPaths.append(os.path.join(resourceDir, schema))
+
+    if assets:
+        assetPaths.extend(assets)
+
+    seen = set()
+    dedupedAssets = []
+    for assetPath in assetPaths:
+        key = os.path.abspath(assetPath)
+        if key not in seen:
+            seen.add(key)
+            dedupedAssets.append(assetPath)
+
+    lines = []
+    if notes is not None:
+        lines.append(notes)
+        lines.append("")
+    lines.append("## Resources")
+    lines.append("")
+    for descriptor in descriptors:
+        name = descriptor.get("name")
+        resourceTitle = descriptor.get("title", name)
+        lines.append("- **{}** (`{}`)".format(resourceTitle, name))
+        description = descriptor.get("description")
+        if description:
+            lines.append("  {}".format(description))
+        sizeBytes = descriptor.get("bytes")
+        hashValue = descriptor.get("hash")
+        detailParts = []
+        if sizeBytes is not None:
+            detailParts.append("{} ({:,} bytes)".format(_format_bytes(sizeBytes), sizeBytes))
+        if hashValue is not None:
+            detailParts.append("`{}`".format(hashValue))
+        if detailParts:
+            lines.append("  {}".format(" — ".join(detailParts)))
+    lines.append("")
+    lines.append("Load with `morpc.frictionless.load_data()` against the resource descriptor attached to this release.")
+    releaseNotes = "\n".join(lines)
+
+    releaseTitle = title if title is not None else tag
+
+    if shutil.which("gh") is None:
+        logger.error("The gh CLI is required to create a GitHub release but was not found on PATH.")
+        raise RuntimeError
+
+    for assetPath in dedupedAssets:
+        if not os.path.exists(assetPath):
+            logger.error("Asset {} does not exist.".format(assetPath))
+            raise RuntimeError
+
+    if not dryRun:
+        result = subprocess.run(["gh", "release", "view", tag, "--repo", "{}/{}".format(owner, repo)], capture_output=True)
+        if result.returncode == 0:
+            logger.error("Release {} already exists in {}/{}. A tag may only be cut once.".format(tag, owner, repo))
+            raise RuntimeError
+
+    if dryRun:
+        logger.info("Dry run. Assets: {}".format(dedupedAssets))
+        logger.info("Dry run. Notes:\n{}".format(releaseNotes))
+        return dedupedAssets, releaseNotes
+
+    subprocess.run(["gh", "release", "create", tag, "--repo", "{}/{}".format(owner, repo),
+                     "--title", releaseTitle, "--notes", releaseNotes, *dedupedAssets], check=True)
+
+    return dedupedAssets, releaseNotes

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -3,16 +3,20 @@
 import datetime
 import os
 import shutil
+import subprocess
 
 import frictionless
 import pytest
 
 from morpc.frictionless import (
     calver,
+    create_release,
     create_resource,
+    prepare_release,
     publish_paths,
     release_asset_url,
     resolve_data_path,
+    write_resource,
 )
 
 
@@ -403,6 +407,300 @@ def test_publish_paths_without_a_path_raises():
     resource = frictionless.Resource.from_descriptor({"name": "parcels", "data": [["id"], [1]]})
     with pytest.raises(RuntimeError):
         publish_paths(resource, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+
+
+# --- prepare_release ---
+
+def test_prepare_release_rewrites_descriptors_and_creates_package(tmp_path):
+    _build_data(tmp_path, name="data1.csv")
+    _build_data(tmp_path, name="data2.csv")
+    resource1Path = tmp_path / "data1.resource.yaml"
+    resource2Path = tmp_path / "data2.resource.yaml"
+    create_resource("data1.csv", resourcePath=str(resource1Path), ignoreSchema=True, name="one", writeResource=True)
+    create_resource("data2.csv", resourcePath=str(resource2Path), ignoreSchema=True, name="two", writeResource=True)
+
+    published = prepare_release(
+        [str(resource1Path), str(resource2Path)],
+        "morpc",
+        "repo",
+        "v2026.7.22",
+        packageName="bundle",
+    )
+
+    assert len(published) == 2
+    assert published[0].path.endswith("/download/v2026.7.22/data1.csv")
+    assert published[1].path.endswith("/download/v2026.7.22/data2.csv")
+
+    # Both descriptors were rewritten on disk, not just returned in memory.
+    reread1 = frictionless.Resource(str(resource1Path))
+    reread2 = frictionless.Resource(str(resource2Path))
+    assert reread1.path.endswith("/download/v2026.7.22/data1.csv")
+    assert reread1.custom["_cache"] == "data1.csv"
+    assert reread2.path.endswith("/download/v2026.7.22/data2.csv")
+    assert reread2.custom["_cache"] == "data2.csv"
+
+    # frictionless.Package.to_yaml() writes resources as bare path strings, which
+    # frictionless.Package() itself cannot re-read (a pre-existing quirk unrelated to this
+    # function), so read the version back as plain YAML instead of round-tripping through frictionless.
+    import yaml
+
+    packageDescriptor = yaml.safe_load((tmp_path / "bundle.package.yaml").read_text())
+    assert packageDescriptor["version"] == "2026.7.22"
+    assert packageDescriptor["resources"] == ["data1.resource.yaml", "data2.resource.yaml"]
+
+
+def test_prepare_release_accepts_a_bare_string_path(tmp_path):
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+
+    published = prepare_release(str(resourcePath), "morpc", "repo", "v2026.7.22")
+
+    assert len(published) == 1
+    assert published[0].path.endswith("/download/v2026.7.22/data.csv")
+
+
+# --- create_release ---
+
+class _FakeCompleted:
+    def __init__(self, returncode):
+        self.returncode = returncode
+
+
+def _build_shared_schema_resources(tmp_path):
+    """Two resources whose schema attribute both point at the same schema sidecar file."""
+    (tmp_path / "shared.schema.yaml").write_text(SCHEMA_YAML)
+    for name in ("data1.csv", "data2.csv"):
+        (tmp_path / name).write_bytes(b"id,name\r\n1,alice\r\n2,bob\r\n")
+
+    resource1Path = tmp_path / "data1.resource.yaml"
+    resource2Path = tmp_path / "data2.resource.yaml"
+    create_resource(
+        "data1.csv", resourcePath=str(resource1Path), schemaPath="shared.schema.yaml", name="one", writeResource=True
+    )
+    create_resource(
+        "data2.csv", resourcePath=str(resource2Path), schemaPath="shared.schema.yaml", name="two", writeResource=True
+    )
+    return str(resource1Path), str(resource2Path)
+
+
+def test_create_release_dedupes_a_schema_shared_by_two_resources(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    resource1Path, resource2Path = _build_shared_schema_resources(tmp_path)
+
+    assets, notes = create_release([resource1Path, resource2Path], "morpc", "repo", "v2026.7.22", dryRun=True)
+
+    absAssets = [os.path.abspath(asset) for asset in assets]
+    assert len(absAssets) == len(set(absAssets))
+    assert absAssets.count(os.path.abspath(tmp_path / "shared.schema.yaml")) == 1
+    assert os.path.abspath(tmp_path / "data1.csv") in absAssets
+    assert os.path.abspath(tmp_path / "data2.csv") in absAssets
+    assert os.path.abspath(resource1Path) in absAssets
+    assert os.path.abspath(resource2Path) in absAssets
+
+
+def test_create_release_resolves_published_data_through_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    local = create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels")
+    published = publish_paths(local, "morpc", "morpc-parcels-standardize", "v2026.7.22")
+    write_resource(published, str(resourcePath))
+
+    assets, notes = create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22", dryRun=True)
+
+    absAssets = [os.path.abspath(asset) for asset in assets]
+    # The data asset resolves through _cache, not the release asset URL, which is not a local path.
+    assert os.path.abspath(tmp_path / "data.csv") in absAssets
+
+
+def test_create_release_url_path_without_cache_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    resourcePath = tmp_path / "data.resource.yaml"
+    resource = frictionless.Resource.from_descriptor({"name": "parcels", "path": ASSET_URL, "format": "csv"})
+    write_resource(resource, str(resourcePath))
+
+    with pytest.raises(RuntimeError):
+        create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22", dryRun=True)
+
+
+def test_create_release_appends_extra_assets(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+    extraPath = tmp_path / "bundle.package.yaml"
+    extraPath.write_text("name: bundle\n")
+
+    assets, notes = create_release(
+        [str(resourcePath)], "morpc", "repo", "v2026.7.22", assets=[str(extraPath)], dryRun=True
+    )
+
+    assert os.path.abspath(extraPath) in [os.path.abspath(asset) for asset in assets]
+
+
+def test_create_release_notes_include_resource_details_and_intro(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource(
+        "data.csv",
+        resourcePath=str(resourcePath),
+        ignoreSchema=True,
+        name="parcels",
+        title="Parcels",
+        description="County parcel data.",
+        writeResource=True,
+    )
+
+    assets, notes = create_release(
+        [str(resourcePath)], "morpc", "repo", "v2026.7.22", notes="Intro text.", dryRun=True
+    )
+
+    assert "Intro text." in notes
+    assert "Parcels" in notes
+    assert "`parcels`" in notes
+    assert "County parcel data." in notes
+    dataBytes = os.path.getsize(tmp_path / "data.csv")
+    assert "{:,} bytes".format(dataBytes) in notes
+    resource = frictionless.Resource(str(resourcePath))
+    assert resource.hash in notes
+
+
+def test_create_release_missing_asset_raises_before_any_gh_call(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+    os.remove(tmp_path / "data.csv")
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("gh should not be invoked when an asset is missing.")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+
+    with pytest.raises(RuntimeError):
+        create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22")
+
+
+def test_create_release_existing_tag_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+
+    def _fake_run(args, **kwargs):
+        assert args[:3] == ["gh", "release", "view"]
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    with pytest.raises(RuntimeError):
+        create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22")
+
+
+def test_create_release_invokes_gh_with_the_expected_arguments(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+
+    calls = []
+
+    def _fake_run(args, **kwargs):
+        calls.append(args)
+        # A non-zero return from the tag check means no such release, so the create proceeds.
+        return _FakeCompleted(1)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    assets, notes = create_release(
+        [str(resourcePath)], "morpc", "repo", "v2026.7.22", title="2026.7.22", notes="Intro text."
+    )
+
+    view, create = calls
+    assert view == ["gh", "release", "view", "v2026.7.22", "--repo", "morpc/repo"]
+    assert create[:6] == ["gh", "release", "create", "v2026.7.22", "--repo", "morpc/repo"]
+    assert create[6:10] == ["--title", "2026.7.22", "--notes", notes]
+    # Every derived asset is passed positionally after the flags, in order.
+    assert create[10:] == assets
+
+
+def test_create_release_title_defaults_to_the_tag(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+
+    calls = []
+
+    def _fake_run(args, **kwargs):
+        calls.append(args)
+        return _FakeCompleted(1)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22")
+
+    create = calls[1]
+    assert create[create.index("--title") + 1] == "v2026.7.22"
+
+
+def test_create_release_missing_gh_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+
+    with pytest.raises(RuntimeError):
+        create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22")
+
+
+def test_prepare_release_bare_filename_packages_into_the_working_directory(tmp_path, monkeypatch):
+    # A descriptor named without a directory has no dirname, so the package directory falls back to ".".
+    monkeypatch.chdir(tmp_path)
+    _build_data(tmp_path)
+    create_resource("data.csv", resourcePath="data.resource.yaml", ignoreSchema=True, name="parcels", writeResource=True)
+
+    prepare_release("data.resource.yaml", "morpc", "repo", "v2026.7.22", packageName="bundle")
+
+    assert os.path.exists(tmp_path / "bundle.package.yaml")
+
+
+def test_prepare_release_descriptors_in_different_directories_raise(tmp_path):
+    first = tmp_path / "a"
+    second = tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+    _build_data(first)
+    _build_data(second)
+    create_resource("data.csv", resourcePath=str(first / "data.resource.yaml"), ignoreSchema=True, name="one", writeResource=True)
+    create_resource("data.csv", resourcePath=str(second / "data.resource.yaml"), ignoreSchema=True, name="two", writeResource=True)
+
+    with pytest.raises(RuntimeError):
+        prepare_release(
+            [str(first / "data.resource.yaml"), str(second / "data.resource.yaml")],
+            "morpc",
+            "repo",
+            "v2026.7.22",
+            packageName="bundle",
+        )
+
+
+def test_create_release_dry_run_skips_tag_check_and_create(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/gh")
+    _build_data(tmp_path)
+    resourcePath = tmp_path / "data.resource.yaml"
+    create_resource("data.csv", resourcePath=str(resourcePath), ignoreSchema=True, name="parcels", writeResource=True)
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("A dry run must not invoke gh at all.")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+
+    assets, notes = create_release([str(resourcePath)], "morpc", "repo", "v2026.7.22", dryRun=True)
+
+    assert len(assets) == 2  # the data file and the descriptor
 
 
 # --- load_data ---


### PR DESCRIPTION
## Why

The `gh release create` step was hand-rolled in each workflow notebook. It handled exactly one resource, re-enumerated its own asset list, and built its release notes from an f-string that could drift from what was actually published. Workflows that produce several resources had no path at all.

## What

Two functions in the existing `morpc/frictionless/release.py`, alongside `publish_paths`/`calver`/`release_asset_url`:

```python
prepare_release(resources, owner, repo, tag, version=None, packageName=None, dir=None)  # -> list[Resource]
create_release(resources, owner, repo, tag, title=None, notes=None, assets=None, dryRun=False)  # -> (assets, notes)
```

- `resources` is a list of descriptor paths; a bare string is accepted so single-resource callers stay a one-liner.
- **`prepare_release`** loops `publish_paths` + `write_resource` over the descriptors and optionally builds the package, deriving the version from the tag so the two cannot drift.
- **`create_release`** derives the asset list from the resources themselves — per resource the data file (through `_cache` when the path is already a published URL), its descriptor, and the schema sidecar when referenced by path — de-duplicated, since resources in one workflow commonly share a schema. `assets=` appends extras such as the package.
- **Notes are built from the descriptors** (title, name, description, size, hash), so a release describes what was published rather than what a format string claimed.
- **Preflight before any upload:** `gh` on PATH, every asset present on disk, and the tag not already taken. A several-hundred-megabyte upload should not fail partway through on a condition knowable up front.
- `dryRun=True` resolves and reports the assets and notes without invoking `gh` at all.

`create_release` takes descriptor paths rather than in-memory `Resource` objects: the descriptor file is itself an asset, and a `Resource` built in memory has no reliable way to report its own descriptor path. This is documented in the docstring.

Version bumped to 0.5.15.

## Testing

`tests/test_release.py`: 40 passed, covering shared-schema de-duplication, `_cache` resolution taking precedence over the URL, URL-without-cache raising, extra assets, notes content, missing-asset and existing-tag both raising before any upload, the dry run invoking no `gh`, the exact `gh release create` argv, and `prepare_release` rewriting several descriptors plus package version.

Full suite: 102 passed, 4 failed. All four failures are pre-existing in `tests/test_utils.py` (datetime/timezone handling) and fail identically on a clean checkout of this branch point; they are untouched here.

Verified end to end with `dryRun=True` against the real descriptors in `morpc-addresspoints-standardize`, which resolved exactly the four assets that repo's hardcoded list had and rendered `175.0 MB (183,545,856 bytes)` with the descriptor's hash.

## Note for reviewers

`create_package()`'s output does not validate when re-read through `frictionless.Package(path)` — resources are written as bare path strings and `created` as a raw datetime. Pre-existing and out of scope here, so the package test parses the YAML directly. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)