### PR TITLE
Write the package created timestamp as a string

### DIFF
--- a/morpc/frictionless/frictionless.py
+++ b/morpc/frictionless/frictionless.py
@@ -1173,7 +1173,9 @@ def create_package(dir: PathLike, resources: List[str], name: str, version: str 
         package = frictionless.Package(
             name=name,
             resources=resources,
-            created=datetime.datetime.now(),
+            # Emitted as an ISO 8601 string rather than a datetime. Frictionless passes the value
+            # through to the descriptor unchanged, and the Data Package spec requires a string here.
+            created=datetime.datetime.now().isoformat(),
             version=str(version),
             keywords=keywords
         )

--- a/tests/test_frictionless.py
+++ b/tests/test_frictionless.py
@@ -236,3 +236,29 @@ def test_load_data_nonspatial_sqlite_returns_plain_dataframe(tmp_path):
     data, resource, schema = load_data(str(resourcePath))
     assert not isinstance(data, gpd.GeoDataFrame)
     assert data["name"].tolist() == ["alice", "bob"]
+
+
+# --- create_package ---
+
+def test_create_package_writes_created_as_an_iso8601_string(tmp_path):
+    import datetime
+
+    import yaml
+
+    from morpc.frictionless import create_package, create_resource
+
+    (tmp_path / "data.csv").write_bytes(b"id,name\r\n1,alice\r\n")
+    create_resource(
+        "data.csv",
+        resourcePath=str(tmp_path / "data.resource.yaml"),
+        ignoreSchema=True,
+        name="parcels",
+        writeResource=True,
+    )
+    create_package(dir=str(tmp_path), resources=["data.resource.yaml"], name="bundle", version="2026.7.30")
+
+    descriptor = yaml.safe_load((tmp_path / "bundle.package.yaml").read_text())
+    # Frictionless passes the value through unchanged, so a datetime would land in the descriptor as
+    # one and the Data Package spec requires a string. See #165.
+    assert isinstance(descriptor["created"], str)
+    datetime.datetime.fromisoformat(descriptor["created"])


### PR DESCRIPTION
Partially addresses #165.

## What

`create_package()` passed `created=datetime.datetime.now()`. Frictionless passes the value through to the descriptor unchanged, so a `datetime` object landed in the YAML where the Data Package spec requires an RFC3339 string:

```yaml
created: 2026-07-30 09:17:49.773407      # before
created: '2026-07-30T09:17:49.773407'    # after
```

One-line change plus a comment explaining why it matters, since the reason lives in frictionless's serialization behavior rather than anywhere visible in our code.

## Scope

This is the safe half of #165. That issue has **two** independent causes, and the other one is deliberately not touched here: resources are emitted as path references (`resources: [data.resource.yaml]`) rather than as objects, which is frictionless's own behavior for a `Resource` constructed from a descriptor path. Fixing that changes the format of every package this library has ever written, including those already published as release assets, so it needs a deliberate decision rather than being folded into a bug fix. See the tradeoff laid out in #165.

Consequence: `frictionless.Package("bundle.package.yaml")` still raises after this change, now on `resources/0` alone rather than on both properties. #165 stays open.

## Testing

New `test_create_package_writes_created_as_an_iso8601_string` in `tests/test_frictionless.py` asserts the written `created` is a string and parses as ISO 8601. Verified it fails on `main` and passes with the fix.

Full suite: 103 passed, 4 failed — the same four pre-existing `tests/test_utils.py` datetime failures that fail identically on `main`, untouched here.

## Note

No version bump, so this is not yet on PyPI. It needs a bump and a release to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)